### PR TITLE
refactor(portfolio): clarify positioning and tighten business-facing …

### DIFF
--- a/portfolio-v2/src/app/about/page.tsx
+++ b/portfolio-v2/src/app/about/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/about",
   title: "About",
-  description: "Freelance software engineer focused on integrations, production systems and maintainable delivery."
+  description: "Software engineer who translates business needs into clear technical work."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/contact/page.tsx
+++ b/portfolio-v2/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/contact",
   title: "Contact",
-  description: "Contact for platforms, integrations, backend work and advanced WordPress projects."
+  description: "Best way to start a project conversation about software, automation or systems."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/contacto/page.tsx
+++ b/portfolio-v2/src/app/es/contacto/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/contacto",
   title: "Contacto",
-  description: "Contacto para plataformas, integraciones, backend y proyectos de WordPress avanzado."
+  description: "La mejor forma de iniciar una conversación sobre software, automatización o sistemas."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/orbytia/page.tsx
+++ b/portfolio-v2/src/app/es/orbytia/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/orbytia",
   title: "Orbytia",
-  description: "Estructura para mis productos y experimentos, separada del trabajo para clientes."
+  description: "Consultoría de software, automatización, IA aplicada y soluciones digitales."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/page.tsx
+++ b/portfolio-v2/src/app/es/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es",
   title: "Hernán Bonavota",
-  description: "Desarrollador freelance para plataformas web, integraciones y sistemas en producción."
+  description: "Desarrollador de software para plataformas, integraciones, backend y trabajo de producto."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/sobre-mi/page.tsx
+++ b/portfolio-v2/src/app/es/sobre-mi/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/sobre-mi",
   title: "Sobre mí",
-  description: "Desarrollador freelance centrado en integraciones, sistemas en producción y software mantenible."
+  description: "Desarrollador de software que traduce necesidades de negocio en trabajo técnico claro."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/trabajo/page.tsx
+++ b/portfolio-v2/src/app/es/trabajo/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/trabajo",
   title: "Trabajo",
-  description: "Trabajos seleccionados entre proyectos para clientes, productos propios y experimentos."
+  description: "Descripciones breves de trabajo para clientes, producto y exploración."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/orbytia/page.tsx
+++ b/portfolio-v2/src/app/orbytia/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/orbytia",
   title: "Orbytia",
-  description: "Structure for my own products and experiments, separate from client work."
+  description: "Software consulting, automation, applied AI and digital solutions."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/page.tsx
+++ b/portfolio-v2/src/app/page.tsx
@@ -5,7 +5,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/",
   title: "Hernán Bonavota",
-  description: "Freelance software engineer for web platforms, integrations and production systems."
+  description: "Software engineer for platforms, integrations, backend and product work."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/work/page.tsx
+++ b/portfolio-v2/src/app/work/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/work",
   title: "Work",
-  description: "Selected work across client projects, own products and experiments."
+  description: "Short descriptions of client work, product work and selected exploration."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/components/pages/about-page.tsx
+++ b/portfolio-v2/src/components/pages/about-page.tsx
@@ -16,8 +16,8 @@ export function AboutPage({ locale }: AboutPageProps) {
         eyebrow={locale === "en" ? "About" : "Sobre mí"}
         title={
           locale === "en"
-            ? "Freelance software engineer."
-            : "Desarrollador freelance."
+            ? "Technical work with business sense."
+            : "Trabajo técnico con sentido de negocio."
         }
         description={content.intro}
       >

--- a/portfolio-v2/src/components/pages/contact-page.tsx
+++ b/portfolio-v2/src/components/pages/contact-page.tsx
@@ -12,10 +12,16 @@ type ContactPageProps = {
 export function ContactPage({ locale }: ContactPageProps) {
   const content = contactPage[locale];
   const links = [
-    { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
-    { label: "GitHub", href: siteConfig.approvedLinks.github },
-    { label: "Orbytia", href: siteConfig.approvedLinks.orbytia },
-    { label: "Verifiko", href: siteConfig.approvedLinks.verifiko }
+    {
+      label: "LinkedIn",
+      href: siteConfig.approvedLinks.linkedin,
+      kicker: locale === "en" ? "Direct message" : "Mensaje directo"
+    },
+    {
+      label: "Orbytia",
+      href: siteConfig.approvedLinks.orbytia,
+      kicker: locale === "en" ? "Services and enquiries" : "Servicios y contacto"
+    }
   ];
 
   return (
@@ -25,7 +31,7 @@ export function ContactPage({ locale }: ContactPageProps) {
         title={content.title}
         description={content.description}
       >
-        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-2">
           {links.map((item) => (
             <Link
               key={item.href}
@@ -33,7 +39,7 @@ export function ContactPage({ locale }: ContactPageProps) {
               className="surface-panel flex h-full min-h-[12.75rem] flex-col justify-between p-[1.625rem] transition hover:border-cyan-200/28 hover:bg-white/[0.06] md:min-h-[13.5rem] md:p-8"
             >
               <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-white/42">
-                {locale === "en" ? "Link" : "Enlace"}
+                {item.kicker}
               </p>
               <div className="mt-8 flex items-end justify-between gap-4">
                 <h2 className="text-[1.5rem] font-semibold tracking-[-0.04em] text-white md:text-[1.6rem]">

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -55,35 +55,35 @@ export function HomePage({ locale }: HomePageProps) {
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-              {locale === "en" ? "Freelance developer" : "Desarrollador freelance"}
+              {locale === "en" ? "Client work" : "Trabajo para clientes"}
             </p>
             <h2 className="mt-5 text-[1.9rem] font-semibold text-white">Hernán Bonavota</h2>
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
               {locale === "en"
-                ? "Client work in platforms, integrations and backend."
-                : "Trabajo para clientes en plataformas, integraciones y backend."}
+                ? "Platforms, integrations and backend for real operations."
+                : "Plataformas, integraciones y backend para operaciones reales."}
             </p>
           </div>
           <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Orbytia</p>
             <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
-              {locale === "en" ? "Own products" : "Productos propios"}
+              {locale === "en" ? "Consulting line" : "Línea de consultoría"}
             </h2>
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
               {locale === "en"
-                ? "Only for my own products."
-                : "Solo para mis productos propios."}
+                ? "Software, automation and applied AI."
+                : "Software, automatización e IA aplicada."}
             </p>
           </div>
           <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">Verifiko</p>
             <h2 className="mt-5 text-[2.15rem] font-semibold text-white">
-              {locale === "en" ? "Visible product" : "Producto visible"}
+              {locale === "en" ? "Product example" : "Ejemplo de producto"}
             </h2>
             <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
               {locale === "en"
-                ? "Verification product built under Orbytia."
-                : "Producto de verificación construido dentro de Orbytia."}
+                ? "A product inside Orbytia, not the main offer."
+                : "Un producto dentro de Orbytia, no la oferta principal."}
             </p>
           </div>
         </div>
@@ -160,24 +160,24 @@ export function HomePage({ locale }: HomePageProps) {
               title: "Hernán Bonavota",
               text:
                 locale === "en"
-                  ? "Client work in platforms, integrations and backend."
-                  : "Trabajo para clientes en plataformas, integraciones y backend.",
+                  ? "Platforms, integrations and backend for real operations."
+                  : "Plataformas, integraciones y backend para operaciones reales.",
               href: siteConfig.portfolioDomains[0]
             },
             {
               title: "Orbytia",
               text:
                 locale === "en"
-                  ? "Only for my own products."
-                  : "Solo para mis productos propios.",
+                  ? "Software, automation and applied AI."
+                  : "Software, automatización e IA aplicada.",
               href: siteConfig.approvedLinks.orbytia
             },
             {
               title: "Verifiko",
               text:
                 locale === "en"
-                  ? "Verification product built under Orbytia."
-                  : "Producto de verificación dentro de Orbytia.",
+                  ? "One product inside Orbytia."
+                  : "Un producto dentro de Orbytia.",
               href: siteConfig.approvedLinks.verifiko
             }
           ].map((item) => (
@@ -205,13 +205,13 @@ export function HomePage({ locale }: HomePageProps) {
         <div className="max-w-4xl space-y-7 text-[1.02rem] leading-8 text-white/68">
           <p>
             {locale === "en"
-              ? "I build interfaces, APIs, integrations and internal tools for real operations."
-              : "Construyo interfaces, APIs, integraciones y herramientas internas para operaciones reales."}
+              ? "Clients usually bring me projects when the need is clear but the path is not."
+              : "Muchas veces me llegan proyectos donde la necesidad está clara, pero el camino no."}
           </p>
           <p>
             {locale === "en"
-              ? "I turn vague requirements into clear technical work."
-              : "Convierto requisitos difusos en trabajo técnico claro."}
+              ? "I help turn that into concrete technical work and keep communication simple."
+              : "Ayudo a convertir eso en trabajo técnico concreto y mantengo la comunicación simple."}
           </p>
         </div>
       </Section>
@@ -225,8 +225,8 @@ export function HomePage({ locale }: HomePageProps) {
         <div className="grid gap-4 md:grid-cols-3">
           {[
             { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
-            { label: "GitHub", href: siteConfig.approvedLinks.github },
-            { label: "Orbytia", href: siteConfig.approvedLinks.orbytia }
+            { label: "Orbytia", href: siteConfig.approvedLinks.orbytia },
+            { label: locale === "en" ? "Let's talk" : "Hablemos", href: getLocalizedPath(locale, "contact") }
           ].map((item) => (
             <Link
               key={item.label}

--- a/portfolio-v2/src/components/pages/orbytia-page.tsx
+++ b/portfolio-v2/src/components/pages/orbytia-page.tsx
@@ -18,8 +18,8 @@ export function OrbytiaPage({ locale }: OrbytiaPageProps) {
         eyebrow="Orbytia"
         title={
           locale === "en"
-            ? "Own products."
-            : "Productos propios."
+            ? "Services, automation and applied AI."
+            : "Servicios, automatización e IA aplicada."
         }
         description={content.intro}
       >

--- a/portfolio-v2/src/components/pages/work-page.tsx
+++ b/portfolio-v2/src/components/pages/work-page.tsx
@@ -11,12 +11,12 @@ type WorkPageProps = {
 export function WorkPage({ locale }: WorkPageProps) {
   const title =
     locale === "en"
-      ? "Client work, own products and experiments."
-      : "Proyectos para clientes, productos propios y experimentos.";
+      ? "What each project is."
+      : "Qué es cada proyecto.";
   const description =
     locale === "en"
-      ? "A quick view of the work I usually take on."
-      : "Una vista rápida del trabajo que suelo hacer.";
+      ? "Client delivery, product work and selected exploration."
+      : "Trabajo para clientes, producto y exploración seleccionada.";
 
   return (
     <SiteFrame locale={locale}>

--- a/portfolio-v2/src/components/site/footer.tsx
+++ b/portfolio-v2/src/components/site/footer.tsx
@@ -11,8 +11,8 @@ export function Footer({ locale }: FooterProps) {
   const externalLabel = locale === "en" ? "External" : "Externo";
   const bottomLine =
     locale === "en"
-      ? "Backend, frontend, WordPress, payments and APIs."
-      : "Backend, frontend, WordPress, pagos y APIs.";
+      ? "Platforms, integrations, backend, product work and automations."
+      : "Plataformas, integraciones, backend, producto y automatizaciones.";
 
   return (
     <footer className="border-t border-white/8 bg-slate-950/92">
@@ -23,13 +23,13 @@ export function Footer({ locale }: FooterProps) {
           </p>
           <h2 className="max-w-lg text-[1.72rem] font-semibold leading-[1.08] tracking-[-0.04em] text-white sm:text-[1.86rem]">
             {locale === "en"
-              ? "Freelance software engineer."
-              : "Desarrollador freelance."}
+              ? "Software engineer for real products and systems."
+              : "Desarrollador de software para productos y sistemas reales."}
           </h2>
           <p className="max-w-lg text-[0.95rem] leading-8 text-white/58">
             {locale === "en"
-              ? "Client work and a few own products."
-              : "Trabajo para clientes y algunos productos propios."}
+              ? "Open to project work and long-term roles."
+              : "Disponible para proyectos y también para roles estables."}
           </p>
         </div>
         <div className="space-y-5 lg:pl-2">
@@ -55,18 +55,13 @@ export function Footer({ locale }: FooterProps) {
               </Link>
             </li>
             <li>
-              <Link href={siteConfig.approvedLinks.github} className="inline-flex transition hover:text-white">
-                GitHub
-              </Link>
-            </li>
-            <li>
-              <Link href={siteConfig.approvedLinks.verifiko} className="inline-flex transition hover:text-white">
-                Verifiko
-              </Link>
-            </li>
-            <li>
               <Link href={siteConfig.approvedLinks.orbytia} className="inline-flex transition hover:text-white">
                 Orbytia
+              </Link>
+            </li>
+            <li>
+              <Link href={siteConfig.approvedLinks.github} className="inline-flex transition hover:text-white">
+                GitHub
               </Link>
             </li>
           </ul>

--- a/portfolio-v2/src/components/site/header.tsx
+++ b/portfolio-v2/src/components/site/header.tsx
@@ -19,7 +19,7 @@ export function Header({ locale }: HeaderProps) {
       <div className="mx-auto flex max-w-[88rem] items-center justify-between gap-4 px-5 py-3.5 sm:gap-6 sm:px-8 lg:px-10 lg:py-4">
         <Link href={homeHref} className="group flex flex-col leading-none text-white">
           <span className="text-[0.58rem] font-medium uppercase tracking-[0.28em] text-cyan-200/42 transition group-hover:text-cyan-200/58 sm:text-[0.62rem]">
-            {locale === "en" ? "Freelance Developer" : "Desarrollador freelance"}
+            {locale === "en" ? "Software Engineer" : "Desarrollador de software"}
           </span>
           <span className="mt-1.5 text-[0.96rem] font-semibold tracking-[-0.03em] text-white sm:mt-2 sm:text-[1.02rem]">
             Hernán Bonavota
@@ -45,7 +45,7 @@ export function Header({ locale }: HeaderProps) {
             href={ctaHref}
             className="rounded-full border border-cyan-300/18 bg-cyan-300/[0.08] px-4.5 py-2.5 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/34 hover:bg-cyan-300/14"
           >
-            {locale === "en" ? "Contact me" : "Contactar"}
+            {locale === "en" ? "Let's talk" : "Hablemos"}
           </Link>
         </div>
         <div className="flex items-center gap-2 lg:hidden">

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -29,8 +29,8 @@ export type CaseStudy = {
 export const siteConfig = {
   name: "Hernán Bonavota",
   description: {
-    en: "Freelance software engineer for web platforms, integrations and production systems.",
-    es: "Desarrollador freelance para plataformas web, integraciones y sistemas en producción."
+    en: "Software engineer for platforms, integrations, backend and product work.",
+    es: "Desarrollador de software para plataformas, integraciones, backend y trabajo de producto."
   },
   domain: "https://hbonavota.com",
   portfolioDomains: ["https://hbonavota.com/", "https://hbonavota.es/"],
@@ -49,7 +49,7 @@ export const categoryLabels: Record<Category, LocalizedText> = {
   product: { en: "Own Product", es: "Producto propio" },
   "client-work": { en: "Client Work", es: "Proyectos para clientes" },
   lab: { en: "Lab", es: "Lab" },
-  ecosystem: { en: "Own Setup", es: "Estructura propia" }
+  ecosystem: { en: "Consulting", es: "Consultoría" }
 };
 
 export const navigation = {
@@ -71,93 +71,93 @@ export const homeContent = {
   en: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Freelance software engineer for platforms, integrations and backend.",
+      title: "Software engineer for platforms, integrations and backend systems.",
       description:
-        "APIs, payments, validation, WordPress and software in production.",
+        "I help teams build and improve software that has to work in real operations.",
       primaryCta: { label: "See work", href: "/work" },
-      secondaryCta: { label: "Contact me", href: "/contact" }
+      secondaryCta: { label: "Let's talk", href: "/contact" }
     },
     selectedWork: {
       eyebrow: "Selected Work",
-      title: "Work built for real operations.",
+      title: "Work for real operations.",
       description:
-        "Client projects, own products and production software."
+        "Short examples of what each project actually is."
     },
     capabilities: {
       eyebrow: "What I Build",
-      title: "What I build.",
+      title: "What I usually build.",
       description:
-        "Integrations, backend, frontend and WordPress."
+        "Platforms, integrations, operational tools and websites that have to work."
     },
     experience: {
       eyebrow: "Current Work",
-      title: "Current work.",
+      title: "Current role in production.",
       description:
-        "Ticketing, payments, validation and backend flows."
+        "Today I work on ticketing, payments, validation and backend flows."
     },
     ecosystem: {
-      eyebrow: "Own Products",
-      title: "Own products, separate from client work.",
+      eyebrow: "Own Work",
+      title: "How Orbytia fits.",
       description:
-        "Client work goes under my name. Orbytia is only for my own products."
+        "Client work stays under my name. Orbytia is the line for software consulting, automation, applied AI and own initiatives."
     },
     about: {
       eyebrow: "About",
       title: "How I work.",
       description:
-        "Clear execution for software used in real operations."
+        "Technical work with business sense and clear communication."
     },
     contact: {
       eyebrow: "Contact",
-      title: "Need a developer for a real platform?",
+      title: "Need help with software that has to work?",
       description:
-        "Backend, integrations, WordPress or full-stack delivery."
+        "Let's talk about your project, your team or the system you need to improve."
     }
   },
   es: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Desarrollador freelance para plataformas, integraciones y backend.",
+      title: "Desarrollador de software para plataformas, integraciones y sistemas backend.",
       description:
-        "APIs, pagos, validación, WordPress y software en producción.",
+        "Ayudo a equipos a construir y mejorar software que tiene que funcionar en operaciones reales.",
       primaryCta: { label: "Ver trabajo", href: "/es/trabajo" },
-      secondaryCta: { label: "Contactar", href: "/es/contacto" }
+      secondaryCta: { label: "Hablemos", href: "/es/contacto" }
     },
     selectedWork: {
       eyebrow: "Trabajo destacado",
       title: "Trabajo para operaciones reales.",
       description:
-        "Proyectos para clientes, productos propios y software en producción."
+        "Ejemplos cortos de qué es cada proyecto."
     },
     capabilities: {
       eyebrow: "Qué construyo",
-      title: "Lo que construyo.",
+      title: "Lo que suelo construir.",
       description:
-        "Integraciones, backend, frontend y WordPress."
+        "Plataformas, integraciones, herramientas operativas y webs que tienen que funcionar."
     },
     experience: {
       eyebrow: "Trabajo actual",
-      title: "Trabajo actual.",
+      title: "Trabajo actual en producción.",
       description:
-        "Ticketing, pagos, validación y flujos backend."
+        "Hoy trabajo con ticketing, pagos, validación y flujos backend."
     },
     ecosystem: {
-      eyebrow: "Productos propios",
-      title: "Productos propios, separados del trabajo para clientes.",
+      eyebrow: "Trabajo propio",
+      title: "Cómo encaja Orbytia.",
       description:
-        "El trabajo para clientes va bajo mi nombre. Orbytia queda solo para mis productos."
+        "El trabajo para clientes sigue bajo mi nombre. Orbytia es la línea para consultoría de software, automatización, IA aplicada e iniciativas propias."
     },
     about: {
       eyebrow: "Sobre mí",
       title: "Cómo trabajo.",
       description:
-        "Ejecución clara para software que se usa en operaciones reales."
+        "Trabajo técnico con sentido de negocio y comunicación clara."
     },
     contact: {
       eyebrow: "Contacto",
-      title: "¿Necesitas un desarrollador para una plataforma real?",
+      title: "¿Necesitas ayuda con software que tiene que funcionar?",
       description:
-        "Backend, integraciones, WordPress o delivery full-stack."
+        "Hablemos de tu proyecto, tu equipo o el sistema que necesitas mejorar."
     }
   }
 } as const;
@@ -166,37 +166,37 @@ export const capabilities = {
   en: [
     {
       title: "Integrations and APIs",
-      text: "Services, internal tools and backend flows."
+      text: "APIs, third-party services and internal flows."
     },
     {
       title: "Transactional platforms",
-      text: "Payments, validation and user flows."
+      text: "Payments, validation and user access."
     },
     {
       title: "Advanced WordPress",
-      text: "Custom builds that stay easy to manage."
+      text: "Custom WordPress for teams that need control."
     },
     {
       title: "Backend and full-stack delivery",
-      text: "Frontend and backend for real operations."
+      text: "Frontend and backend connected to real operations."
     }
   ],
   es: [
     {
       title: "Integraciones y APIs",
-      text: "Servicios, herramientas internas y flujos backend."
+      text: "APIs, servicios externos y flujos internos."
     },
     {
       title: "Plataformas transaccionales",
-      text: "Pagos, validaciones y recorridos de usuario."
+      text: "Pagos, validaciones y acceso de usuarios."
     },
     {
       title: "WordPress avanzado",
-      text: "Desarrollos a medida fáciles de mantener."
+      text: "WordPress a medida para equipos que necesitan control."
     },
     {
       title: "Backend y full-stack",
-      text: "Frontend y backend para operaciones reales."
+      text: "Frontend y backend conectados a operaciones reales."
     }
   ]
 } as const;
@@ -208,17 +208,17 @@ export const professionalExperience = {
     es: "Software Engineer / Product Engineer"
   },
   summary: {
-    en: "At Rezolve I work on ticketing, payments, validation and backend flows for high-traffic production systems.",
+    en: "At Rezolve I work on ticketing, payments, validation and backend flows in high-traffic production systems.",
     es: "En Rezolve trabajo con ticketing, pagos, validación y backend sobre sistemas en producción de alto tráfico."
   },
   notes: {
     en: [
       "High-traffic transactional systems.",
-      "Work tied to day-to-day operations."
+      "Work tied to day-to-day club operations."
     ],
     es: [
       "Sistemas transaccionales de alto tráfico.",
-      "Trabajo ligado a operaciones reales."
+      "Trabajo ligado a operaciones reales de club."
     ]
   }
 } as const;
@@ -226,43 +226,43 @@ export const professionalExperience = {
 export const aboutPage = {
   en: {
     intro:
-      "I build software for companies that need execution, not just ideas.",
+      "Clients usually hire me when they need someone who can understand the problem, bring order to it and move the work forward.",
     sections: [
       {
         title: "How I work",
         body:
-          "I reduce ambiguity early and focus on what needs to ship."
+          "I listen first, ask the right questions and turn vague needs into concrete steps."
       },
       {
-        title: "What I build",
+        title: "What they value",
         body:
-          "Integrations, backends, WordPress, internal tools and business platforms."
+          "Technical judgment, product sense and communication that works with non-technical people too."
       },
       {
         title: "Why clients hire me",
         body:
-          "I turn messy requirements into working software."
+          "That usually leads to clearer scope, better decisions and software that is easier to ship and maintain."
       }
     ]
   },
   es: {
     intro:
-      "Construyo software para empresas que necesitan ejecución, no solo ideas.",
+      "Normalmente me contratan cuando hace falta alguien que entienda el problema, le ponga orden y ayude a sacar el trabajo adelante.",
     sections: [
       {
         title: "Cómo trabajo",
         body:
-          "Reduzco ambigüedad pronto y me centro en lo que hay que entregar."
+          "Primero escucho, hago las preguntas correctas y convierto necesidades difusas en pasos concretos."
       },
       {
-        title: "Qué construyo",
+        title: "Qué valoran",
         body:
-          "Integraciones, backend, WordPress, herramientas internas y plataformas de negocio."
+          "Criterio técnico, visión de producto y una comunicación que también funciona con perfiles no técnicos."
       },
       {
         title: "Por qué me contratan",
         body:
-          "Convierto requisitos desordenados en software que funciona."
+          "Eso suele traducirse en mejor enfoque, mejores decisiones y software más fácil de lanzar y mantener."
       }
     ]
   }
@@ -271,43 +271,43 @@ export const aboutPage = {
 export const orbytiaPage = {
   en: {
     intro:
-      "Orbytia is the label for my own products.",
+      "Orbytia is the line I use for software consulting, automation, applied AI and digital solutions.",
     sections: [
       {
         title: "What it is",
         body:
-          "Own products and experiments."
+          "A practical entry point for services and own initiatives."
       },
       {
         title: "How it fits",
         body:
-          "Client work stays under my name."
+          "My main professional identity is still Hernán Bonavota."
       },
       {
         title: "Why it matters",
         body:
-          "It keeps product work separate from freelance work."
+          "It gives clients a clear place to explore services and start a conversation."
       }
     ]
   },
   es: {
     intro:
-      "Orbytia es la etiqueta para mis productos propios.",
+      "Orbytia es la línea que uso para consultoría de software, automatización, IA aplicada y soluciones digitales.",
     sections: [
       {
         title: "Qué es",
         body:
-          "Productos propios y experimentos."
+          "Un punto de entrada práctico para servicios e iniciativas propias."
       },
       {
         title: "Cómo encaja",
         body:
-          "El trabajo para clientes sigue bajo mi nombre."
+          "Mi identidad profesional principal sigue siendo Hernán Bonavota."
       },
       {
         title: "Por qué importa",
         body:
-          "Separa el trabajo de producto del trabajo freelance."
+          "Da un lugar claro para explorar servicios e iniciar conversación."
       }
     ]
   }
@@ -315,14 +315,14 @@ export const orbytiaPage = {
 
 export const contactPage = {
   en: {
-    title: "Project contact.",
+    title: "Let's talk about your project.",
     description:
-      "If you need help with software, integrations or backend work, write me here."
+      "LinkedIn works well for a first message. Orbytia is the best place to explore services, automation and applied AI work."
   },
   es: {
-    title: "Contacto para proyectos.",
+    title: "Hablemos de tu proyecto.",
     description:
-      "Si necesitas ayuda con software, integraciones o backend, puedes escribirme por aquí."
+      "LinkedIn funciona bien para un primer contacto. Orbytia es el mejor punto de entrada para servicios, automatización e IA aplicada."
   }
 } as const;
 
@@ -334,12 +334,12 @@ export const caseStudies: CaseStudy[] = [
     pageRequired: true,
     title: { en: "Verifiko", es: "Verifiko" },
     strapline: {
-      en: "Own product.",
-      es: "Producto propio."
+      en: "Cybersecurity product.",
+      es: "Producto de ciberseguridad."
     },
     summary: {
-      en: "Verification flows, backend checks and product thinking.",
-      es: "Flujos de verificación, lógica backend y trabajo de producto."
+      en: "Own product that analyzes URLs and detects signs of risk.",
+      es: "Producto propio de ciberseguridad para analizar URLs y detectar señales de riesgo."
     },
     role: {
       en: "Founder / Product Engineer",
@@ -347,44 +347,44 @@ export const caseStudies: CaseStudy[] = [
     },
     overview: {
       en: [
-        "Own product focused on trust and validation."
+        "A product built to help users review suspicious URLs faster."
       ],
       es: [
-        "Producto propio centrado en confianza y validación."
+        "Un producto pensado para ayudar a revisar URLs sospechosas con más rapidez."
       ]
     },
     challenge: {
       en: [
-        "The flow had to feel clear from the first step."
+        "The product had to make technical checks easier to understand."
       ],
       es: [
-        "El flujo tenía que entenderse desde el primer paso."
+        "El producto tenía que hacer comprensibles unas comprobaciones técnicas."
       ]
     },
     approach: {
       en: [
-        "I simplified the path and supported it with backend logic."
+        "I focused on clarity, analysis signals and backend logic."
       ],
       es: [
-        "Simplifiqué el recorrido y lo apoyé con lógica backend."
+        "Lo enfoqué en claridad, señales de análisis y lógica backend."
       ]
     },
     highlights: {
       en: [
-        "Verification flow.",
-        "Backend logic."
+        "URL analysis.",
+        "Risk signals."
       ],
       es: [
-        "Flujo de verificación.",
-        "Lógica backend."
+        "Análisis de URLs.",
+        "Señales de riesgo."
       ]
     },
     outcome: {
       en: [
-        "Shows how I build product around trust and real use."
+        "Shows product work around cybersecurity, backend and clarity."
       ],
       es: [
-        "Muestra cómo construyo producto alrededor de confianza y uso real."
+        "Muestra trabajo de producto en ciberseguridad, backend y claridad."
       ]
     },
     publicLinks: [
@@ -399,12 +399,12 @@ export const caseStudies: CaseStudy[] = [
     pageRequired: true,
     title: { en: "Orbytia", es: "Orbytia" },
     strapline: {
-      en: "Own setup.",
-      es: "Estructura propia."
+      en: "Services and consulting.",
+      es: "Servicios y consultoría."
     },
     summary: {
-      en: "Structure for my own products, separate from client work.",
-      es: "Estructura para mis productos, separada del trabajo para clientes."
+      en: "Software consulting, applied AI, automation and web projects.",
+      es: "Consultoría de software, IA aplicada, automatización y proyectos web."
     },
     role: {
       en: "Founder / Builder",
@@ -412,44 +412,44 @@ export const caseStudies: CaseStudy[] = [
     },
     overview: {
       en: [
-        "It explains where products like Verifiko fit."
+        "A clearer service entry point for software, automation and digital work."
       ],
       es: [
-        "Explica dónde encajan productos como Verifiko."
+        "Un punto de entrada más claro para servicios de software, automatización y trabajo digital."
       ]
     },
     challenge: {
       en: [
-        "Without it, product work and client work compete."
+        "It needed to explain the service side without turning into a vague brand."
       ],
       es: [
-        "Sin ella, producto propio y trabajo para clientes se mezclan."
+        "Tenía que explicar la parte de servicios sin convertirse en una marca ambigua."
       ]
     },
     approach: {
       en: [
-        "My name is for client work. Orbytia is for own products."
+        "I kept Hernán as the main identity and used Orbytia as the service and enquiry layer."
       ],
       es: [
-        "Trabajo con clientes bajo mi nombre. Orbytia queda para producto propio."
+        "Mantuve a Hernán como identidad principal y usé Orbytia como capa de servicios y entrada de contacto."
       ]
     },
     highlights: {
       en: [
-        "Own products.",
-        "Separate from client work."
+        "Software consulting.",
+        "Automation and AI."
       ],
       es: [
-        "Productos propios.",
-        "Separado del trabajo para clientes."
+        "Consultoría de software.",
+        "Automatización e IA."
       ]
     },
     outcome: {
       en: [
-        "It keeps the site easier to read."
+        "Shows a service line that is useful, concrete and easy to contact."
       ],
       es: [
-        "Hace la web más fácil de entender."
+        "Presenta una línea de servicios útil, concreta y fácil de contactar."
       ]
     },
     publicLinks: [{ label: "Orbytia", href: siteConfig.approvedLinks.orbytia }]
@@ -465,8 +465,8 @@ export const caseStudies: CaseStudy[] = [
       es: "Plataforma para cliente."
     },
     summary: {
-      en: "Business platform for day-to-day operations.",
-      es: "Plataforma de negocio para la operativa diaria."
+      en: "Website with an online quoting system for renovation work.",
+      es: "Web con sistema de presupuesto online para obras de reforma."
     },
     role: {
       en: "Full-stack Developer / Web Platform Engineer",
@@ -474,44 +474,44 @@ export const caseStudies: CaseStudy[] = [
     },
     overview: {
       en: [
-        "Client work for a platform used day to day."
+        "A business website with a quotation flow built into the experience."
       ],
       es: [
-        "Trabajo para cliente sobre una plataforma de uso diario."
+        "Una web de negocio con un sistema de presupuestos integrado en la experiencia."
       ]
     },
     challenge: {
       en: [
-        "It had to be clear and easy to maintain."
+        "The quoting flow had to be clear for users and manageable for the business."
       ],
       es: [
-        "Tenía que ser clara y fácil de mantener."
+        "El flujo de presupuesto tenía que ser claro para el usuario y fácil de gestionar para el negocio."
       ]
     },
     approach: {
       en: [
-        "I worked on structure, frontend and backend delivery."
+        "I worked on the website, the quotation flow and the delivery around it."
       ],
       es: [
-        "Trabajé la estructura y el delivery frontend y backend."
+        "Trabajé la web, el flujo de presupuesto y el delivery técnico que lo sostenía."
       ]
     },
     highlights: {
       en: [
-        "Business platform.",
-        "Maintainable delivery."
+        "Online quotes.",
+        "Business website."
       ],
       es: [
-        "Plataforma de negocio.",
-        "Delivery mantenible."
+        "Presupuesto online.",
+        "Web de negocio."
       ]
     },
     outcome: {
       en: [
-        "Shows reliable execution for client work."
+        "Shows practical delivery for a business website tied to a real process."
       ],
       es: [
-        "Muestra ejecución fiable en trabajo para clientes."
+        "Muestra un delivery práctico para una web de negocio ligada a un proceso real."
       ]
     },
     publicLinks: [{ label: "Proyectar SL", href: siteConfig.approvedLinks.proyectar }]
@@ -523,12 +523,12 @@ export const caseStudies: CaseStudy[] = [
     pageRequired: true,
     title: { en: "Tu Próximo Seguro", es: "Tu Próximo Seguro" },
     strapline: {
-      en: "Client website.",
-      es: "Web para cliente."
+      en: "Lead generation website.",
+      es: "Web de captación."
     },
     summary: {
-      en: "Business website built for trust and conversion.",
-      es: "Web de negocio centrada en confianza y conversión."
+      en: "Lead generation website for an insurance advisor.",
+      es: "Web para captación de leads de una asesora de seguros."
     },
     role: {
       en: "Web / Product Engineer",
@@ -536,44 +536,44 @@ export const caseStudies: CaseStudy[] = [
     },
     overview: {
       en: [
-        "A public site where clarity directly affects contact."
+        "A business website where trust and clarity directly affect enquiries."
       ],
       es: [
-        "Una web pública donde la claridad afecta al contacto."
+        "Una web de negocio donde la confianza y la claridad afectan directamente al contacto."
       ]
     },
     challenge: {
       en: [
-        "Users had to understand the offer fast."
+        "The offer had to be easy to understand and easy to contact."
       ],
       es: [
-        "El usuario tenía que entender la propuesta rápido."
+        "La propuesta tenía que entenderse rápido y facilitar el contacto."
       ]
     },
     approach: {
       en: [
-        "I focused on structure, trust signals and frontend delivery."
+        "I focused on content structure, trust signals and a straightforward frontend."
       ],
       es: [
-        "Lo enfoqué en estructura, señales de confianza y delivery frontend."
+        "Lo enfoqué en estructura de contenido, señales de confianza y un frontend directo."
       ]
     },
     highlights: {
       en: [
-        "Clear offer.",
-        "Trust-focused UX."
+        "Lead capture.",
+        "Trust signals."
       ],
       es: [
-        "Oferta clara.",
-        "UX orientada a confianza."
+        "Captación de leads.",
+        "Señales de confianza."
       ]
     },
     outcome: {
       en: [
-        "Shows web delivery where clarity helps conversion."
+        "Shows web delivery built to support enquiries."
       ],
       es: [
-        "Muestra delivery web donde la claridad ayuda a convertir."
+        "Muestra un delivery web pensado para apoyar el contacto."
       ]
     },
     publicLinks: [
@@ -591,8 +591,8 @@ export const caseStudies: CaseStudy[] = [
       es: "Trabajo experimental."
     },
     summary: {
-      en: "Early product exploration kept in the lab category.",
-      es: "Exploración de producto en fase temprana dentro del lab."
+      en: "Early product exploration kept clearly as lab work.",
+      es: "Exploración de producto en fase temprana, presentada claramente como lab."
     },
     role: {
       en: "Concept / Experimental Builder",


### PR DESCRIPTION
## Summary

This PR refines the portfolio positioning and simplifies the bilingual copy across the visible marketing layer.

Main goals:
- remove “freelance” as the core positioning
- make the offer clearer for both project work and potential long-term roles
- present Orbytia as a concrete consulting / automation / applied AI line
- explain each case study in faster, more practical language
- keep English and Spanish aligned in tone, intent and hierarchy

## What changed

- rewrote home, work, about, Orbytia and contact copy
- improved business-facing messaging in header and footer
- reduced noise and abstract branding language
- made case summaries and straplines more concrete
- adjusted contact flow to prioritize useful entry points
- updated route metadata to match the new positioning

## Validation

- npm run build ✅
- npm run typecheck ✅