### PR TITLE
Feat/portfolio rebuild

### DIFF
--- a/portfolio-v2/next-env.d.ts
+++ b/portfolio-v2/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/portfolio-v2/next-env.d.ts
+++ b/portfolio-v2/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/portfolio-v2/src/app/about/page.tsx
+++ b/portfolio-v2/src/app/about/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/about",
   title: "About",
-  description: "Software engineer who translates business needs into clear technical work."
+  description: "Software engineer who turns ambiguous needs into clear technical execution."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/contact/page.tsx
+++ b/portfolio-v2/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/contact",
   title: "Contact",
-  description: "Best way to start a project conversation about software, automation or systems."
+  description: "Best route for recruiters, hiring managers and technical conversations."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/contacto/page.tsx
+++ b/portfolio-v2/src/app/es/contacto/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/contacto",
   title: "Contacto",
-  description: "La mejor forma de iniciar una conversación sobre software, automatización o sistemas."
+  description: "La mejor vía para recruiters, hiring managers y conversaciones técnicas."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/orbytia/page.tsx
+++ b/portfolio-v2/src/app/es/orbytia/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/orbytia",
   title: "Orbytia",
-  description: "Consultoría de software, automatización, IA aplicada y soluciones digitales."
+  description: "Línea separada de consultoría para software, automatización e IA aplicada para clientes."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/page.tsx
+++ b/portfolio-v2/src/app/es/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es",
   title: "Hernán Bonavota",
-  description: "Desarrollador de software para plataformas, integraciones, backend y trabajo de producto."
+  description: "Ingeniero de software enfocado en plataformas, integraciones, sistemas backend y desarrollo de producto."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/sobre-mi/page.tsx
+++ b/portfolio-v2/src/app/es/sobre-mi/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/sobre-mi",
   title: "Sobre mí",
-  description: "Desarrollador de software que traduce necesidades de negocio en trabajo técnico claro."
+  description: "Ingeniero de software que convierte necesidades ambiguas en ejecución técnica clara."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/trabajo/page.tsx
+++ b/portfolio-v2/src/app/es/trabajo/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/trabajo",
   title: "Trabajo",
-  description: "Descripciones breves de trabajo para clientes, producto y exploración."
+  description: "Casos seleccionados de trabajo para clientes, producto y proyectos exploratorios."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/orbytia/page.tsx
+++ b/portfolio-v2/src/app/orbytia/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/orbytia",
   title: "Orbytia",
-  description: "Software consulting, automation, applied AI and digital solutions."
+  description: "Separate consulting line for software, automation and applied AI for clients."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/page.tsx
+++ b/portfolio-v2/src/app/page.tsx
@@ -5,7 +5,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/",
   title: "Hernán Bonavota",
-  description: "Software engineer for platforms, integrations, backend and product work."
+  description: "Software engineer focused on platforms, integrations, backend systems and product development."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/work/page.tsx
+++ b/portfolio-v2/src/app/work/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/work",
   title: "Work",
-  description: "Short descriptions of client work, product work and selected exploration."
+  description: "Selected case studies across client projects, product work and exploratory projects."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/components/pages/about-page.tsx
+++ b/portfolio-v2/src/components/pages/about-page.tsx
@@ -16,8 +16,8 @@ export function AboutPage({ locale }: AboutPageProps) {
         eyebrow={locale === "en" ? "About" : "Sobre mí"}
         title={
           locale === "en"
-            ? "Technical work with business sense."
-            : "Trabajo técnico con sentido de negocio."
+            ? "How I work with teams and ambiguous problems."
+            : "Cómo trabajo con equipos y problemas ambiguos."
         }
         description={content.intro}
       >

--- a/portfolio-v2/src/components/pages/contact-page.tsx
+++ b/portfolio-v2/src/components/pages/contact-page.tsx
@@ -20,7 +20,7 @@ export function ContactPage({ locale }: ContactPageProps) {
     {
       label: "Orbytia",
       href: siteConfig.approvedLinks.orbytia,
-      kicker: locale === "en" ? "Services and enquiries" : "Servicios y contacto"
+      kicker: locale === "en" ? "Service enquiries" : "Consultas de servicios"
     }
   ];
 

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -55,7 +55,7 @@ export function HomePage({ locale }: HomePageProps) {
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-              {locale === "en" ? "Client work" : "Trabajo para clientes"}
+              {locale === "en" ? "Client work" : "Si buscas un desarrollador de Software"}
             </p>
             <h2 className="mt-5 text-[1.9rem] font-semibold text-white">Hernán Bonavota</h2>
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
@@ -65,25 +65,25 @@ export function HomePage({ locale }: HomePageProps) {
             </p>
           </div>
           <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Orbytia</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Si tienes un proyecto en mente</p>
             <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
-              {locale === "en" ? "Consulting line" : "Línea de consultoría"}
+              {locale === "en" ? "Consulting line" : "OrbytIA"}
             </h2>
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
               {locale === "en"
                 ? "Software, automation and applied AI."
-                : "Software, automatización e IA aplicada."}
+                : " Te ayudamos creando Software, automatizaciones e IA aplicada."}
             </p>
           </div>
           <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">Verifiko</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">Ciberseguridad</p>
             <h2 className="mt-5 text-[2.15rem] font-semibold text-white">
-              {locale === "en" ? "Product example" : "Ejemplo de producto"}
+              {locale === "en" ? "Product example" : "Verifiko"}
             </h2>
             <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
               {locale === "en"
                 ? "A product inside Orbytia, not the main offer."
-                : "Un producto dentro de Orbytia, no la oferta principal."}
+                : "Proyecto desarrollado por orbytIA, si tienes una URL que parece peligrosa, analizala con Verifiko"}
             </p>
           </div>
         </div>

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -55,7 +55,7 @@ export function HomePage({ locale }: HomePageProps) {
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-              {locale === "en" ? "Client work" : "Si buscas un desarrollador de Software"}
+              {locale === "en" ? "Professional profile" : "Perfil profesional"}
             </p>
             <h2 className="mt-5 text-[1.9rem] font-semibold text-white">Hernán Bonavota</h2>
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
@@ -65,25 +65,29 @@ export function HomePage({ locale }: HomePageProps) {
             </p>
           </div>
           <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Si tienes un proyecto en mente</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
+              {locale === "en" ? "Separate line" : "Línea separada"}
+            </p>
             <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
-              {locale === "en" ? "Consulting line" : "OrbytIA"}
+              {locale === "en" ? "Orbytia" : "Orbytia"}
             </h2>
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
               {locale === "en"
-                ? "Software, automation and applied AI."
-                : " Te ayudamos creando Software, automatizaciones e IA aplicada."}
+                ? "Consulting, software, automation and applied AI."
+                : "Consultoría, software, automatización e IA aplicada."}
             </p>
           </div>
           <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">Ciberseguridad</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">
+              {locale === "en" ? "Own product" : "Producto propio"}
+            </p>
             <h2 className="mt-5 text-[2.15rem] font-semibold text-white">
-              {locale === "en" ? "Product example" : "Verifiko"}
+              {locale === "en" ? "Verifiko" : "Verifiko"}
             </h2>
             <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
               {locale === "en"
-                ? "A product inside Orbytia, not the main offer."
-                : "Proyecto desarrollado por orbytIA, si tienes una URL que parece peligrosa, analizala con Verifiko"}
+                ? "Cybersecurity product and a concrete example of product work."
+                : "Producto de ciberseguridad y ejemplo concreto de trabajo de producto."}
             </p>
           </div>
         </div>
@@ -168,16 +172,16 @@ export function HomePage({ locale }: HomePageProps) {
               title: "Orbytia",
               text:
                 locale === "en"
-                  ? "Software, automation and applied AI."
-                  : "Software, automatización e IA aplicada.",
+                  ? "Consulting, software, automation and applied AI."
+                  : "Consultoría, software, automatización e IA aplicada.",
               href: siteConfig.approvedLinks.orbytia
             },
             {
               title: "Verifiko",
               text:
                 locale === "en"
-                  ? "One product inside Orbytia."
-                  : "Un producto dentro de Orbytia.",
+                  ? "Cybersecurity product and product-work example."
+                  : "Producto de ciberseguridad y ejemplo de trabajo de producto.",
               href: siteConfig.approvedLinks.verifiko
             }
           ].map((item) => (
@@ -188,7 +192,7 @@ export function HomePage({ locale }: HomePageProps) {
                 href={item.href}
                 className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-cyan-100 hover:text-white"
               >
-                {locale === "en" ? "Open link" : "Abrir enlace"}
+                {locale === "en" ? "Visit" : "Visitar"}
                 <span aria-hidden="true">↗</span>
               </Link>
             </div>
@@ -205,13 +209,13 @@ export function HomePage({ locale }: HomePageProps) {
         <div className="max-w-4xl space-y-7 text-[1.02rem] leading-8 text-white/68">
           <p>
             {locale === "en"
-              ? "Clients usually bring me projects when the need is clear but the path is not."
-              : "Muchas veces me llegan proyectos donde la necesidad está clara, pero el camino no."}
+              ? "I usually work best where the need is clear but the path still needs structure."
+              : "Suelo trabajar mejor cuando la necesidad está clara pero el camino todavía necesita estructura."}
           </p>
           <p>
             {locale === "en"
-              ? "I help turn that into concrete technical work and keep communication simple."
-              : "Ayudo a convertir eso en trabajo técnico concreto y mantengo la comunicación simple."}
+              ? "I help turn that into concrete technical work, sensible decisions and clear communication."
+              : "Ayudo a convertir eso en trabajo técnico concreto, decisiones sensatas y comunicación clara."}
           </p>
         </div>
       </Section>
@@ -226,7 +230,7 @@ export function HomePage({ locale }: HomePageProps) {
           {[
             { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
             { label: "Orbytia", href: siteConfig.approvedLinks.orbytia },
-            { label: locale === "en" ? "Let's talk" : "Hablemos", href: getLocalizedPath(locale, "contact") }
+            { label: locale === "en" ? "Contact" : "Contacto", href: getLocalizedPath(locale, "contact") }
           ].map((item) => (
             <Link
               key={item.label}

--- a/portfolio-v2/src/components/pages/orbytia-page.tsx
+++ b/portfolio-v2/src/components/pages/orbytia-page.tsx
@@ -18,8 +18,8 @@ export function OrbytiaPage({ locale }: OrbytiaPageProps) {
         eyebrow="Orbytia"
         title={
           locale === "en"
-            ? "Services, automation and applied AI."
-            : "Servicios, automatización e IA aplicada."
+            ? "Separate line for consulting, software, automation and applied AI."
+            : "Línea separada para consultoría, software, automatización e IA aplicada."
         }
         description={content.intro}
       >
@@ -36,8 +36,8 @@ export function OrbytiaPage({ locale }: OrbytiaPageProps) {
         <div className="surface-accent rounded-[2rem] p-7 md:p-8">
           <p className="max-w-[42rem] text-[0.98rem] leading-7 text-white/74">
             {locale === "en"
-              ? "Relevant links."
-              : "Enlaces relevantes."}
+              ? "Relevant links for context."
+              : "Enlaces de contexto."}
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link

--- a/portfolio-v2/src/components/pages/work-page.tsx
+++ b/portfolio-v2/src/components/pages/work-page.tsx
@@ -11,12 +11,12 @@ type WorkPageProps = {
 export function WorkPage({ locale }: WorkPageProps) {
   const title =
     locale === "en"
-      ? "What each project is."
-      : "Qué es cada proyecto.";
+      ? "Projects, scope and role."
+      : "Proyectos, alcance y papel.";
   const description =
     locale === "en"
-      ? "Client delivery, product work and selected exploration."
-      : "Trabajo para clientes, producto y exploración seleccionada.";
+      ? "Client projects, product work and exploratory work, explained with clear scope and role."
+      : "Trabajo para clientes, producto y exploración, explicados con claridad en alcance y papel.";
 
   return (
     <SiteFrame locale={locale}>

--- a/portfolio-v2/src/components/site/case-card.tsx
+++ b/portfolio-v2/src/components/site/case-card.tsx
@@ -35,7 +35,7 @@ export function CaseCard({ locale, study }: CaseCardProps) {
           href={getLocalizedPath(locale, "work", study.slug)}
           className="inline-flex items-center gap-2 text-sm font-semibold text-white transition hover:text-cyan-200"
         >
-          {locale === "en" ? "View details" : "Ver caso"}
+          {locale === "en" ? "View case" : "Ver caso"}
           <span
             aria-hidden="true"
             className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/[0.04]"

--- a/portfolio-v2/src/components/site/footer.tsx
+++ b/portfolio-v2/src/components/site/footer.tsx
@@ -11,8 +11,8 @@ export function Footer({ locale }: FooterProps) {
   const externalLabel = locale === "en" ? "External" : "Externo";
   const bottomLine =
     locale === "en"
-      ? "Platforms, integrations, backend, product work and automations."
-      : "Plataformas, integraciones, backend, producto y automatizaciones.";
+      ? "Platforms, integrations, backend systems and product development."
+      : "Plataformas, integraciones, sistemas backend y desarrollo de producto.";
 
   return (
     <footer className="border-t border-white/8 bg-slate-950/92">
@@ -23,13 +23,13 @@ export function Footer({ locale }: FooterProps) {
           </p>
           <h2 className="max-w-lg text-[1.72rem] font-semibold leading-[1.08] tracking-[-0.04em] text-white sm:text-[1.86rem]">
             {locale === "en"
-              ? "Software engineer for real products and systems."
-              : "Desarrollador de software."}
+              ? "Software engineer for platforms, integrations and backend systems."
+              : "Ingeniero de software para plataformas, integraciones y sistemas backend."}
           </h2>
           <p className="max-w-lg text-[0.95rem] leading-8 text-white/58">
             {locale === "en"
-              ? "Open to project work and long-term roles."
-              : "Contáctame y te responderé a la mayor brevedad posible."}
+              ? "Open to roles, collaborations and technical conversations."
+              : "Abierto a oportunidades, colaboraciones y conversaciones técnicas."}
           </p>
         </div>
         <div className="space-y-5 lg:pl-2">

--- a/portfolio-v2/src/components/site/footer.tsx
+++ b/portfolio-v2/src/components/site/footer.tsx
@@ -24,12 +24,12 @@ export function Footer({ locale }: FooterProps) {
           <h2 className="max-w-lg text-[1.72rem] font-semibold leading-[1.08] tracking-[-0.04em] text-white sm:text-[1.86rem]">
             {locale === "en"
               ? "Software engineer for real products and systems."
-              : "Desarrollador de software para productos y sistemas reales."}
+              : "Desarrollador de software."}
           </h2>
           <p className="max-w-lg text-[0.95rem] leading-8 text-white/58">
             {locale === "en"
               ? "Open to project work and long-term roles."
-              : "Disponible para proyectos y también para roles estables."}
+              : "Contáctame y te responderé a la mayor brevedad posible."}
           </p>
         </div>
         <div className="space-y-5 lg:pl-2">

--- a/portfolio-v2/src/components/site/header.tsx
+++ b/portfolio-v2/src/components/site/header.tsx
@@ -19,7 +19,7 @@ export function Header({ locale }: HeaderProps) {
       <div className="mx-auto flex max-w-[88rem] items-center justify-between gap-4 px-5 py-3.5 sm:gap-6 sm:px-8 lg:px-10 lg:py-4">
         <Link href={homeHref} className="group flex flex-col leading-none text-white">
           <span className="text-[0.58rem] font-medium uppercase tracking-[0.28em] text-cyan-200/42 transition group-hover:text-cyan-200/58 sm:text-[0.62rem]">
-            {locale === "en" ? "Software Engineer" : "Desarrollador de software"}
+            {locale === "en" ? "Software Engineer" : "Ingeniero de software"}
           </span>
           <span className="mt-1.5 text-[0.96rem] font-semibold tracking-[-0.03em] text-white sm:mt-2 sm:text-[1.02rem]">
             Hernán Bonavota
@@ -45,7 +45,7 @@ export function Header({ locale }: HeaderProps) {
             href={ctaHref}
             className="rounded-full border border-cyan-300/18 bg-cyan-300/[0.08] px-4.5 py-2.5 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/34 hover:bg-cyan-300/14"
           >
-            {locale === "en" ? "Let's talk" : "Hablemos"}
+            {locale === "en" ? "Contact" : "Contacto"}
           </Link>
         </div>
         <div className="flex items-center gap-2 lg:hidden">

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -117,9 +117,9 @@ export const homeContent = {
   es: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Desarrollador de software para plataformas, integraciones y sistemas backend.",
+      title: "Desarrollador de software, con experiencia en productos.",
       description:
-        "Ayudo a equipos a construir y mejorar software que tiene que funcionar en operaciones reales.",
+        "Ayudo a equipos a construir y mejorar software que impactan en operaciones reales.",
       primaryCta: { label: "Ver trabajo", href: "/es/trabajo" },
       secondaryCta: { label: "Hablemos", href: "/es/contacto" }
     },
@@ -322,7 +322,7 @@ export const contactPage = {
   es: {
     title: "Hablemos de tu proyecto.",
     description:
-      "LinkedIn funciona bien para un primer contacto. Orbytia es el mejor punto de entrada para servicios, automatización e IA aplicada."
+      "Para propuestas laborales, puedes contactarme directamente por LinkedIn. Si quieres que evaluemos tu proyecto envia la información a través de OrbytIA"
   }
 } as const;
 
@@ -462,11 +462,11 @@ export const caseStudies: CaseStudy[] = [
     title: { en: "Proyectar SL", es: "Proyectar SL" },
     strapline: {
       en: "Client platform.",
-      es: "Plataforma para cliente."
+      es: "Web de empresa que se dedica a construcción y reformas."
     },
     summary: {
       en: "Website with an online quoting system for renovation work.",
-      es: "Web con sistema de presupuesto online para obras de reforma."
+      es: "Desarrollo completo de portal de empresa con sistema personalizado para la realización de presupuestos online."
     },
     role: {
       en: "Full-stack Developer / Web Platform Engineer",
@@ -528,7 +528,7 @@ export const caseStudies: CaseStudy[] = [
     },
     summary: {
       en: "Lead generation website for an insurance advisor.",
-      es: "Web para captación de leads de una asesora de seguros."
+      es: "Web para cliente personal asesora de seguros que funciona para prospección de Leads ."
     },
     role: {
       en: "Web / Product Engineer",
@@ -592,7 +592,7 @@ export const caseStudies: CaseStudy[] = [
     },
     summary: {
       en: "Early product exploration kept clearly as lab work.",
-      es: "Exploración de producto en fase temprana, presentada claramente como lab."
+      es: "Exploración de producto en fase temprana."
     },
     role: {
       en: "Concept / Experimental Builder",

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -29,8 +29,8 @@ export type CaseStudy = {
 export const siteConfig = {
   name: "Hernán Bonavota",
   description: {
-    en: "Software engineer for platforms, integrations, backend and product work.",
-    es: "Desarrollador de software para plataformas, integraciones, backend y trabajo de producto."
+    en: "Software engineer focused on platforms, integrations, backend systems and product development.",
+    es: "Ingeniero de software enfocado en plataformas, integraciones, sistemas backend y desarrollo de producto."
   },
   domain: "https://hbonavota.com",
   portfolioDomains: ["https://hbonavota.com/", "https://hbonavota.es/"],
@@ -46,10 +46,10 @@ export const siteConfig = {
 } as const;
 
 export const categoryLabels: Record<Category, LocalizedText> = {
-  product: { en: "Own Product", es: "Producto propio" },
-  "client-work": { en: "Client Work", es: "Proyectos para clientes" },
+  product: { en: "Product", es: "Producto" },
+  "client-work": { en: "Client Project", es: "Trabajo para clientes" },
   lab: { en: "Lab", es: "Lab" },
-  ecosystem: { en: "Consulting", es: "Consultoría" }
+  ecosystem: { en: "Consulting Line", es: "Línea de consultoría" }
 };
 
 export const navigation = {
@@ -73,33 +73,33 @@ export const homeContent = {
       eyebrow: "Hernán Bonavota",
       title: "Software engineer for platforms, integrations and backend systems.",
       description:
-        "I help teams build and improve software that has to work in real operations.",
+        "I build and improve software that has to hold up in real operations.",
       primaryCta: { label: "See work", href: "/work" },
-      secondaryCta: { label: "Let's talk", href: "/contact" }
+      secondaryCta: { label: "Contact", href: "/contact" }
     },
     selectedWork: {
       eyebrow: "Selected Work",
-      title: "Work for real operations.",
+      title: "Work grounded in real operations.",
       description:
-        "Short examples of what each project actually is."
+        "Short case studies focused on the project, the need and my role."
     },
     capabilities: {
       eyebrow: "What I Build",
-      title: "What I usually build.",
+      title: "What I build most often.",
       description:
         "Platforms, integrations, operational tools and websites that have to work."
     },
     experience: {
       eyebrow: "Current Work",
-      title: "Current role in production.",
+      title: "Current work in production.",
       description:
         "Today I work on ticketing, payments, validation and backend flows."
     },
     ecosystem: {
-      eyebrow: "Own Work",
-      title: "How Orbytia fits.",
+      eyebrow: "Professional Context",
+      title: "Where Orbytia fits.",
       description:
-        "Client work stays under my name. Orbytia is the line for software consulting, automation, applied AI and own initiatives."
+        "This portfolio is my main professional profile. Orbytia appears here only as the separate line for consulting, automation, applied AI and related work."
     },
     about: {
       eyebrow: "About",
@@ -109,29 +109,29 @@ export const homeContent = {
     },
     contact: {
       eyebrow: "Contact",
-      title: "Need help with software that has to work?",
+      title: "Open to roles, collaborations and technical conversations.",
       description:
-        "Let's talk about your project, your team or the system you need to improve."
+        "Best for recruiters, hiring managers or teams evaluating fit. Orbytia stays as the separate route for service enquiries."
     }
   },
   es: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Desarrollador de software, con experiencia en productos.",
+      title: "Ingeniero de software para plataformas, integraciones y sistemas backend.",
       description:
-        "Ayudo a equipos a construir y mejorar software que impactan en operaciones reales.",
+        "Construyo y mejoro software que tiene que responder bien en operaciones reales.",
       primaryCta: { label: "Ver trabajo", href: "/es/trabajo" },
-      secondaryCta: { label: "Hablemos", href: "/es/contacto" }
+      secondaryCta: { label: "Contacto", href: "/es/contacto" }
     },
     selectedWork: {
       eyebrow: "Trabajo destacado",
-      title: "Trabajo para operaciones reales.",
+      title: "Trabajo con base en operaciones reales.",
       description:
-        "Ejemplos cortos de qué es cada proyecto."
+        "Casos breves centrados en el proyecto, la necesidad y mi papel."
     },
     capabilities: {
       eyebrow: "Qué construyo",
-      title: "Lo que suelo construir.",
+      title: "Lo que construyo con más frecuencia.",
       description:
         "Plataformas, integraciones, herramientas operativas y webs que tienen que funcionar."
     },
@@ -142,10 +142,10 @@ export const homeContent = {
         "Hoy trabajo con ticketing, pagos, validación y flujos backend."
     },
     ecosystem: {
-      eyebrow: "Trabajo propio",
-      title: "Cómo encaja Orbytia.",
+      eyebrow: "Contexto profesional",
+      title: "Dónde encaja Orbytia.",
       description:
-        "El trabajo para clientes sigue bajo mi nombre. Orbytia es la línea para consultoría de software, automatización, IA aplicada e iniciativas propias."
+        "Este portfolio es mi perfil profesional principal. Orbytia aparece aquí solo como línea separada para consultoría, automatización, IA aplicada y trabajo relacionado."
     },
     about: {
       eyebrow: "Sobre mí",
@@ -155,9 +155,9 @@ export const homeContent = {
     },
     contact: {
       eyebrow: "Contacto",
-      title: "¿Necesitas ayuda con software que tiene que funcionar?",
+      title: "Abierto a oportunidades, colaboraciones y conversaciones técnicas.",
       description:
-        "Hablemos de tu proyecto, tu equipo o el sistema que necesitas mejorar."
+        "Es la mejor vía para recruiters, hiring managers o equipos que quieran valorar encaje. Orbytia queda como canal separado para consultas de servicios."
     }
   }
 } as const;
@@ -177,7 +177,7 @@ export const capabilities = {
       text: "Custom WordPress for teams that need control."
     },
     {
-      title: "Backend and full-stack delivery",
+      title: "Backend and full-stack development",
       text: "Frontend and backend connected to real operations."
     }
   ],
@@ -208,8 +208,8 @@ export const professionalExperience = {
     es: "Software Engineer / Product Engineer"
   },
   summary: {
-    en: "At Rezolve I work on ticketing, payments, validation and backend flows in high-traffic production systems.",
-    es: "En Rezolve trabajo con ticketing, pagos, validación y backend sobre sistemas en producción de alto tráfico."
+    en: "At Rezolve I work on ticketing, payments, validation and backend flows in high-traffic production systems tied to day-to-day club operations.",
+    es: "En Rezolve trabajo con ticketing, pagos, validación y flujos backend sobre sistemas en producción de alto tráfico ligados a la operativa diaria del club."
   },
   notes: {
     en: [
@@ -218,7 +218,7 @@ export const professionalExperience = {
     ],
     es: [
       "Sistemas transaccionales de alto tráfico.",
-      "Trabajo ligado a operaciones reales de club."
+      "Trabajo ligado a la operativa diaria de un club."
     ]
   }
 } as const;
@@ -226,7 +226,7 @@ export const professionalExperience = {
 export const aboutPage = {
   en: {
     intro:
-      "Clients usually hire me when they need someone who can understand the problem, bring order to it and move the work forward.",
+      "I usually add the most value when a team needs someone who can understand the problem, bring structure to it and move execution forward.",
     sections: [
       {
         title: "How I work",
@@ -234,12 +234,12 @@ export const aboutPage = {
           "I listen first, ask the right questions and turn vague needs into concrete steps."
       },
       {
-        title: "What they value",
+        title: "What teams value",
         body:
           "Technical judgment, product sense and communication that works with non-technical people too."
       },
       {
-        title: "Why clients hire me",
+        title: "What that produces",
         body:
           "That usually leads to clearer scope, better decisions and software that is easier to ship and maintain."
       }
@@ -247,7 +247,7 @@ export const aboutPage = {
   },
   es: {
     intro:
-      "Normalmente me contratan cuando hace falta alguien que entienda el problema, le ponga orden y ayude a sacar el trabajo adelante.",
+      "Suelo aportar más valor cuando un equipo necesita a alguien que entienda el problema, le dé estructura y ayude a empujar la ejecución.",
     sections: [
       {
         title: "Cómo trabajo",
@@ -255,12 +255,12 @@ export const aboutPage = {
           "Primero escucho, hago las preguntas correctas y convierto necesidades difusas en pasos concretos."
       },
       {
-        title: "Qué valoran",
+        title: "Qué valoran los equipos",
         body:
           "Criterio técnico, visión de producto y una comunicación que también funciona con perfiles no técnicos."
       },
       {
-        title: "Por qué me contratan",
+        title: "Lo que eso produce",
         body:
           "Eso suele traducirse en mejor enfoque, mejores decisiones y software más fácil de lanzar y mantener."
       }
@@ -271,43 +271,43 @@ export const aboutPage = {
 export const orbytiaPage = {
   en: {
     intro:
-      "Orbytia is the line I use for software consulting, automation, applied AI and digital solutions.",
+      "Orbytia is the separate line for consulting, software, automation and applied AI for clients.",
     sections: [
       {
         title: "What it is",
         body:
-          "A practical entry point for services and own initiatives."
+          "A separate service line, not the main focus of this portfolio."
       },
       {
         title: "How it fits",
         body:
-          "My main professional identity is still Hernán Bonavota."
+          "My main professional identity here is still Hernán Bonavota."
       },
       {
-        title: "Why it matters",
+        title: "Why it appears here",
         body:
-          "It gives clients a clear place to explore services and start a conversation."
+          "It helps explain the consulting context around part of my work and the initiatives that sit next to my personal profile."
       }
     ]
   },
   es: {
     intro:
-      "Orbytia es la línea que uso para consultoría de software, automatización, IA aplicada y soluciones digitales.",
+      "Orbytia es la línea separada para consultoría, software, automatización e IA aplicada para clientes.",
     sections: [
       {
         title: "Qué es",
         body:
-          "Un punto de entrada práctico para servicios e iniciativas propias."
+          "Una línea de servicios separada, no el foco principal de este portfolio."
       },
       {
         title: "Cómo encaja",
         body:
-          "Mi identidad profesional principal sigue siendo Hernán Bonavota."
+          "Mi identidad profesional principal aquí sigue siendo Hernán Bonavota."
       },
       {
-        title: "Por qué importa",
+        title: "Por qué aparece aquí",
         body:
-          "Da un lugar claro para explorar servicios e iniciar conversación."
+          "Ayuda a explicar el contexto de consultoría alrededor de parte de mi trabajo y las iniciativas que conviven con mi perfil personal."
       }
     ]
   }
@@ -315,14 +315,14 @@ export const orbytiaPage = {
 
 export const contactPage = {
   en: {
-    title: "Let's talk about your project.",
+    title: "Open to roles, collaborations and technical conversations.",
     description:
-      "LinkedIn works well for a first message. Orbytia is the best place to explore services, automation and applied AI work."
+      "For roles, collaborations or technical conversations, LinkedIn is the best first contact. Orbytia is only for service enquiries."
   },
   es: {
-    title: "Hablemos de tu proyecto.",
+    title: "Abierto a oportunidades, colaboraciones y conversaciones técnicas.",
     description:
-      "Para propuestas laborales, puedes contactarme directamente por LinkedIn. Si quieres que evaluemos tu proyecto envia la información a través de OrbytIA"
+      "Para oportunidades, colaboraciones o conversaciones técnicas, LinkedIn es el mejor primer contacto. Orbytia queda solo para consultas de servicios."
   }
 } as const;
 
@@ -338,8 +338,8 @@ export const caseStudies: CaseStudy[] = [
       es: "Producto de ciberseguridad."
     },
     summary: {
-      en: "Own product that analyzes URLs and detects signs of risk.",
-      es: "Producto propio de ciberseguridad para analizar URLs y detectar señales de riesgo."
+      en: "Cybersecurity product for analyzing suspicious URLs and surfacing risk signals.",
+      es: "Producto de ciberseguridad para analizar URLs sospechosas y mostrar señales de riesgo."
     },
     role: {
       en: "Founder / Product Engineer",
@@ -347,10 +347,10 @@ export const caseStudies: CaseStudy[] = [
     },
     overview: {
       en: [
-        "A product built to help users review suspicious URLs faster."
+        "A product built to help users review suspicious URLs faster and with more clarity."
       ],
       es: [
-        "Un producto pensado para ayudar a revisar URLs sospechosas con más rapidez."
+        "Un producto pensado para revisar URLs sospechosas con más rapidez y más claridad."
       ]
     },
     challenge: {
@@ -381,10 +381,10 @@ export const caseStudies: CaseStudy[] = [
     },
     outcome: {
       en: [
-        "Shows product work around cybersecurity, backend and clarity."
+        "Shows product work around cybersecurity, backend logic and clarity."
       ],
       es: [
-        "Muestra trabajo de producto en ciberseguridad, backend y claridad."
+        "Muestra trabajo de producto en ciberseguridad, lógica backend y claridad."
       ]
     },
     publicLinks: [
@@ -399,12 +399,12 @@ export const caseStudies: CaseStudy[] = [
     pageRequired: true,
     title: { en: "Orbytia", es: "Orbytia" },
     strapline: {
-      en: "Services and consulting.",
-      es: "Servicios y consultoría."
+      en: "Separate consulting line.",
+      es: "Línea separada de consultoría."
     },
     summary: {
-      en: "Software consulting, applied AI, automation and web projects.",
-      es: "Consultoría de software, IA aplicada, automatización y proyectos web."
+      en: "Separate line for consulting, software, automation and applied AI for clients.",
+      es: "Línea separada para consultoría, software, automatización e IA aplicada para clientes."
     },
     role: {
       en: "Founder / Builder",
@@ -412,26 +412,26 @@ export const caseStudies: CaseStudy[] = [
     },
     overview: {
       en: [
-        "A clearer service entry point for software, automation and digital work."
+        "A separate line that groups service work and related initiatives without replacing my personal professional profile."
       ],
       es: [
-        "Un punto de entrada más claro para servicios de software, automatización y trabajo digital."
+        "Una línea separada que agrupa servicios e iniciativas relacionadas sin sustituir mi perfil profesional personal."
       ]
     },
     challenge: {
       en: [
-        "It needed to explain the service side without turning into a vague brand."
+        "It had to explain the service side clearly without diluting the personal portfolio."
       ],
       es: [
-        "Tenía que explicar la parte de servicios sin convertirse en una marca ambigua."
+        "Tenía que explicar la parte de servicios con claridad sin diluir el portfolio personal."
       ]
     },
     approach: {
       en: [
-        "I kept Hernán as the main identity and used Orbytia as the service and enquiry layer."
+        "I kept Hernán Bonavota as the main profile and positioned Orbytia as complementary context."
       ],
       es: [
-        "Mantuve a Hernán como identidad principal y usé Orbytia como capa de servicios y entrada de contacto."
+        "Mantuve a Hernán Bonavota como perfil principal y situé Orbytia como contexto complementario."
       ]
     },
     highlights: {
@@ -446,10 +446,10 @@ export const caseStudies: CaseStudy[] = [
     },
     outcome: {
       en: [
-        "Shows a service line that is useful, concrete and easy to contact."
+        "Shows the consulting context around part of my work without making it the main story."
       ],
       es: [
-        "Presenta una línea de servicios útil, concreta y fácil de contactar."
+        "Muestra el contexto de consultoría alrededor de parte de mi trabajo sin convertirlo en la historia principal."
       ]
     },
     publicLinks: [{ label: "Orbytia", href: siteConfig.approvedLinks.orbytia }]
@@ -461,12 +461,12 @@ export const caseStudies: CaseStudy[] = [
     pageRequired: true,
     title: { en: "Proyectar SL", es: "Proyectar SL" },
     strapline: {
-      en: "Client platform.",
-      es: "Web de empresa que se dedica a construcción y reformas."
+      en: "Business website and quoting flow.",
+      es: "Web corporativa y flujo de presupuestos."
     },
     summary: {
-      en: "Website with an online quoting system for renovation work.",
-      es: "Desarrollo completo de portal de empresa con sistema personalizado para la realización de presupuestos online."
+      en: "Company website with a custom online quoting flow for renovation work.",
+      es: "Web corporativa con un flujo de presupuestos online a medida para trabajos de reforma."
     },
     role: {
       en: "Full-stack Developer / Web Platform Engineer",
@@ -490,10 +490,10 @@ export const caseStudies: CaseStudy[] = [
     },
     approach: {
       en: [
-        "I worked on the website, the quotation flow and the delivery around it."
+        "I worked on the website, the quotation flow and the technical implementation behind it."
       ],
       es: [
-        "Trabajé la web, el flujo de presupuesto y el delivery técnico que lo sostenía."
+        "Trabajé la web, el flujo de presupuesto y la implementación técnica que lo sostenía."
       ]
     },
     highlights: {
@@ -508,10 +508,10 @@ export const caseStudies: CaseStudy[] = [
     },
     outcome: {
       en: [
-        "Shows practical delivery for a business website tied to a real process."
+        "Shows practical execution for a business website tied to a real process."
       ],
       es: [
-        "Muestra un delivery práctico para una web de negocio ligada a un proceso real."
+        "Muestra una ejecución práctica en una web de negocio ligada a un proceso real."
       ]
     },
     publicLinks: [{ label: "Proyectar SL", href: siteConfig.approvedLinks.proyectar }]
@@ -527,8 +527,8 @@ export const caseStudies: CaseStudy[] = [
       es: "Web de captación."
     },
     summary: {
-      en: "Lead generation website for an insurance advisor.",
-      es: "Web para cliente personal asesora de seguros que funciona para prospección de Leads ."
+      en: "Lead-generation website for an insurance advisor, built to generate trust and make first contact easier.",
+      es: "Web de captación para una asesora de seguros, planteada para generar confianza y facilitar el primer contacto."
     },
     role: {
       en: "Web / Product Engineer",
@@ -570,10 +570,10 @@ export const caseStudies: CaseStudy[] = [
     },
     outcome: {
       en: [
-        "Shows web delivery built to support enquiries."
+        "Shows web work built to support lead generation and first contact."
       ],
       es: [
-        "Muestra un delivery web pensado para apoyar el contacto."
+        "Muestra un trabajo web pensado para apoyar la captación de leads y el primer contacto."
       ]
     },
     publicLinks: [
@@ -591,8 +591,8 @@ export const caseStudies: CaseStudy[] = [
       es: "Trabajo experimental."
     },
     summary: {
-      en: "Early product exploration kept clearly as lab work.",
-      es: "Exploración de producto en fase temprana."
+      en: "Early product exploration kept clearly framed as lab work.",
+      es: "Exploración de producto en fase temprana, presentada claramente como trabajo de laboratorio."
     },
     role: {
       en: "Concept / Experimental Builder",


### PR DESCRIPTION
This PR tightens the portfolio copy around a recruiter-first positioning and improves EN/ES consistency across the site.

What changed
- Reframed the portfolio around professional profile, technical execution, and real operational context
- Reduced commercial / agency-like language in key sections
- Kept Orbytia as secondary context instead of the main story
- Improved copy consistency between Spanish and English
- Clarified project summaries and case-study language
- Cleaned up labels, metadata, and footer/header microcopy

Main areas updated
- Home
- About
- Work
- Contact
- Orbytia
- Case-study labels and summaries
- Header / footer
- Route metadata

Validation
- npm run build ✅
- npm run typecheck ✅