### PR TITLE
Feat/portfolio rebuild

### DIFF
--- a/portfolio-v2/src/components/pages/about-page.tsx
+++ b/portfolio-v2/src/components/pages/about-page.tsx
@@ -16,8 +16,8 @@ export function AboutPage({ locale }: AboutPageProps) {
         eyebrow={locale === "en" ? "About" : "Sobre mí"}
         title={
           locale === "en"
-            ? "How I work with teams and ambiguous problems."
-            : "Cómo trabajo con equipos y problemas ambiguos."
+            ? "How I work with teams and ambiguity."
+            : "Cómo trabajo con equipos y contextos ambiguos."
         }
         description={content.intro}
       >

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -180,8 +180,8 @@ export function HomePage({ locale }: HomePageProps) {
               title: "Verifiko",
               text:
                 locale === "en"
-                  ? "Cybersecurity product and product-work example."
-                  : "Producto de ciberseguridad y ejemplo de trabajo de producto.",
+                  ? "Cybersecurity product and clear product example."
+                  : "Producto de ciberseguridad y ejemplo claro de trabajo de producto.",
               href: siteConfig.approvedLinks.verifiko
             }
           ].map((item) => (

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -91,7 +91,7 @@ export const homeContent = {
     },
     experience: {
       eyebrow: "Current Work",
-      title: "Current work in production.",
+      title: "Current production work.",
       description:
         "Today I work on ticketing, payments, validation and backend flows."
     },
@@ -125,7 +125,7 @@ export const homeContent = {
     },
     selectedWork: {
       eyebrow: "Trabajo destacado",
-      title: "Trabajo con base en operaciones reales.",
+      title: "Trabajo ligado a operaciones reales.",
       description:
         "Casos breves centrados en el proyecto, la necesidad y mi papel."
     },
@@ -276,7 +276,7 @@ export const orbytiaPage = {
       {
         title: "What it is",
         body:
-          "A separate service line, not the main focus of this portfolio."
+          "A separate consulting line, not the main focus of this portfolio."
       },
       {
         title: "How it fits",
@@ -297,7 +297,7 @@ export const orbytiaPage = {
       {
         title: "Qué es",
         body:
-          "Una línea de servicios separada, no el foco principal de este portfolio."
+          "Una línea de consultoría separada, no el foco principal de este portfolio."
       },
       {
         title: "Cómo encaja",
@@ -322,7 +322,7 @@ export const contactPage = {
   es: {
     title: "Abierto a oportunidades, colaboraciones y conversaciones técnicas.",
     description:
-      "Para oportunidades, colaboraciones o conversaciones técnicas, puedes contactarme por LinkedIn como mejor contacto. Si quieres que anilicemos tu proyecto ingresa en Orbytia."
+      "Para oportunidades, colaboraciones o conversaciones técnicas, LinkedIn es el mejor primer contacto. Orbytia queda solo para consultas de servicios."
   }
 } as const;
 

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -322,7 +322,7 @@ export const contactPage = {
   es: {
     title: "Abierto a oportunidades, colaboraciones y conversaciones técnicas.",
     description:
-      "Para oportunidades, colaboraciones o conversaciones técnicas, LinkedIn es el mejor primer contacto. Orbytia queda solo para consultas de servicios."
+      "Para oportunidades, colaboraciones o conversaciones técnicas, puedes contactarme por LinkedIn como mejor contacto. Si quieres que anilicemos tu proyecto ingresa en Orbytia."
   }
 } as const;
 


### PR DESCRIPTION
Small editorial polish pass on the portfolio copy.

This update keeps the recruiter-first positioning intact and only refines a few phrases that still felt slightly rigid in English and Spanish. No structural, layout or logic changes were made.

Changes:
- improved naturalness in the About page heading
- refined current work wording in EN and ES
- preserved bilingual consistency and existing positioning
- validated with build and typecheck

Validation:
- npm run build ✅
- npm run typecheck ✅