### PR TITLE
refactor(portfolio): remove Orbytia from main flow and strengthen hiring-focused positioning

### DIFF
--- a/portfolio-v2/src/app/es/contacto/page.tsx
+++ b/portfolio-v2/src/app/es/contacto/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/contacto",
   title: "Contacto",
-  description: "Mejor primer contacto para recruiters, hiring managers y conversaciones técnicas."
+  description: "Vía directa de contacto para oportunidades de ingeniería y conversaciones técnicas."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/orbytia/page.tsx
+++ b/portfolio-v2/src/app/es/orbytia/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/orbytia",
   title: "Orbytia",
-  description: "Contexto secundario de consultoría para parte del trabajo con clientes en software, automatización e IA aplicada."
+  description: "Contexto secundario de consultoría alrededor de parte del trabajo con clientes."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/page.tsx
+++ b/portfolio-v2/src/app/es/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es",
   title: "Hernán Bonavota",
-  description: "Ingeniero de software enfocado en portales de ticketing, integraciones, sistemas backend y trabajo de producto orientado a operación."
+  description: "Ingeniero de software enfocado en integraciones, backend, validación y trabajo de producto en producción."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/trabajo/page.tsx
+++ b/portfolio-v2/src/app/es/trabajo/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/trabajo",
   title: "Trabajo",
-  description: "Case studies sobre ticketing, validación de socios, control de concurrencia y trabajo de producto."
+  description: "Casos sobre validación, concurrencia, integraciones y producto en producción."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/components/pages/contact-page.tsx
+++ b/portfolio-v2/src/components/pages/contact-page.tsx
@@ -17,11 +17,15 @@ export function ContactPage({ locale }: ContactPageProps) {
       href: siteConfig.approvedLinks.linkedin,
       kicker: locale === "en" ? "Direct message" : "Mensaje directo"
     },
-    {
-      label: "Orbytia",
-      href: siteConfig.approvedLinks.orbytia,
-      kicker: locale === "en" ? "Services only" : "Solo servicios"
-    }
+    ...(locale === "en"
+      ? [
+          {
+            label: "Orbytia",
+            href: siteConfig.approvedLinks.orbytia,
+            kicker: locale === "en" ? "Services only" : "Solo servicios"
+          }
+        ]
+      : [])
   ];
 
   return (
@@ -31,7 +35,7 @@ export function ContactPage({ locale }: ContactPageProps) {
         title={content.title}
         description={content.description}
       >
-        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-2">
+        <div className={`grid gap-5 ${locale === "en" ? "md:grid-cols-2 xl:grid-cols-2" : "md:grid-cols-1 xl:grid-cols-1"}`}>
           {links.map((item) => (
             <Link
               key={item.href}

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -20,7 +20,10 @@ type HomePageProps = {
 
 export function HomePage({ locale }: HomePageProps) {
   const content = homeContent[locale];
-  const featured = caseStudies.filter((study) => study.featured);
+  const featured =
+    locale === "en"
+      ? caseStudies.filter((study) => study.featured)
+      : caseStudies.filter((study) => study.featured && study.category === "client-work");
 
   return (
     <SiteFrame locale={locale}>
@@ -61,22 +64,24 @@ export function HomePage({ locale }: HomePageProps) {
             <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
               {locale === "en"
                 ? "Ticketing, integrations and backend for production portals."
-                : "Ticketing, integraciones y backend para portales en producción."}
+                : "Integraciones, backend y producto en producción."}
             </p>
           </div>
-          <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-              {locale === "en" ? "Secondary context" : "Contexto secundario"}
-            </p>
-            <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
-              {locale === "en" ? "Orbytia" : "Orbytia"}
-            </h2>
-            <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
-              {locale === "en"
-                ? "Separate consulting context for selected client work."
-                : "Contexto de consultoría separado para parte del trabajo con clientes."}
-            </p>
-          </div>
+          {locale === "en" ? (
+            <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
+                {locale === "en" ? "Secondary context" : "Contexto secundario"}
+              </p>
+              <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
+                {locale === "en" ? "Orbytia" : "Orbytia"}
+              </h2>
+              <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
+                {locale === "en"
+                  ? "Separate consulting context for selected client work."
+                  : "Contexto de consultoría separado para parte del trabajo con clientes."}
+              </p>
+            </div>
+          ) : null}
           <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">
               {locale === "en" ? "Own product" : "Producto propio"}
@@ -87,7 +92,7 @@ export function HomePage({ locale }: HomePageProps) {
             <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
               {locale === "en"
                 ? "Own product and a concrete example of product engineering outside client delivery."
-                : "Producto propio y ejemplo concreto de trabajo de producto fuera de la entrega a clientes."}
+                : "Producto propio y ejemplo complementario de trabajo de producto fuera de la entrega a clientes."}
             </p>
           </div>
         </div>
@@ -152,53 +157,55 @@ export function HomePage({ locale }: HomePageProps) {
         </div>
       </Section>
 
-      <Section
-        id="ecosystem"
-        eyebrow={content.ecosystem.eyebrow}
-        title={content.ecosystem.title}
-        description={content.ecosystem.description}
-      >
-        <div className="grid gap-6 lg:grid-cols-3">
-          {[
-            {
-              title: "Hernán Bonavota",
-              text:
-                locale === "en"
-                  ? "Ticketing, integrations and backend for production portals."
-                  : "Ticketing, integraciones y backend para portales en producción.",
-              href: siteConfig.portfolioDomains[0]
-            },
-            {
-              title: "Orbytia",
-              text:
-                locale === "en"
-                  ? "Secondary consulting context, separate from the main hiring path."
-                  : "Contexto de consultoría secundario, separado de la vía principal de contratación.",
-              href: siteConfig.approvedLinks.orbytia
-            },
-            {
-              title: "Verifiko",
-              text:
-                locale === "en"
-                  ? "Own product and supporting evidence of product work."
-                  : "Producto propio y evidencia complementaria de trabajo de producto.",
-              href: siteConfig.approvedLinks.verifiko
-            }
-          ].map((item) => (
-            <div key={item.title} className="surface-panel rounded-[2.1rem] p-[1.625rem] md:p-8">
-              <h3 className="text-[1.45rem] font-semibold text-white">{item.title}</h3>
-              <p className="mt-4 text-[0.98rem] leading-8 text-white/64">{item.text}</p>
-              <Link
-                href={item.href}
-                className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-cyan-100 hover:text-white"
-              >
-                {locale === "en" ? "Visit" : "Visitar"}
-                <span aria-hidden="true">↗</span>
-              </Link>
-            </div>
-          ))}
-        </div>
-      </Section>
+      {locale === "en" ? (
+        <Section
+          id="ecosystem"
+          eyebrow={content.ecosystem.eyebrow}
+          title={content.ecosystem.title}
+          description={content.ecosystem.description}
+        >
+          <div className="grid gap-6 lg:grid-cols-3">
+            {[
+              {
+                title: "Hernán Bonavota",
+                text:
+                  locale === "en"
+                    ? "Ticketing, integrations and backend for production portals."
+                    : "Ticketing, integraciones y backend para portales en producción.",
+                href: siteConfig.portfolioDomains[0]
+              },
+              {
+                title: "Orbytia",
+                text:
+                  locale === "en"
+                    ? "Secondary consulting context, separate from the main hiring path."
+                    : "Contexto de consultoría secundario, separado de la vía principal de contratación.",
+                href: siteConfig.approvedLinks.orbytia
+              },
+              {
+                title: "Verifiko",
+                text:
+                  locale === "en"
+                    ? "Own product and supporting evidence of product work."
+                    : "Producto propio y evidencia complementaria de trabajo de producto.",
+                href: siteConfig.approvedLinks.verifiko
+              }
+            ].map((item) => (
+              <div key={item.title} className="surface-panel rounded-[2.1rem] p-[1.625rem] md:p-8">
+                <h3 className="text-[1.45rem] font-semibold text-white">{item.title}</h3>
+                <p className="mt-4 text-[0.98rem] leading-8 text-white/64">{item.text}</p>
+                <Link
+                  href={item.href}
+                  className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-cyan-100 hover:text-white"
+                >
+                  {locale === "en" ? "Visit" : "Visitar"}
+                  <span aria-hidden="true">↗</span>
+                </Link>
+              </div>
+            ))}
+          </div>
+        </Section>
+      ) : null}
 
       <Section
         id="about"
@@ -210,12 +217,12 @@ export function HomePage({ locale }: HomePageProps) {
           <p>
             {locale === "en"
               ? "Most of my work sits where the business need is already visible but the implementation still needs definition, ownership and execution."
-              : "Gran parte de mi trabajo aparece cuando la necesidad de negocio ya es visible pero la implementación todavía necesita definición, responsabilidad y ejecución."}
+              : "Suelo aportar más cuando la necesidad de negocio ya está clara pero todavía hace falta definir, decidir e implementar bien."}
           </p>
           <p>
             {locale === "en"
               ? "That usually means moving between client conversations, technical decisions, implementation and release without handing the problem off."
-              : "Eso suele implicar moverme entre conversaciones con cliente, decisiones técnicas, implementación y salida a producción sin ir traspasando el problema a otra persona."}
+              : "Eso suele implicar moverme entre conversación con cliente, decisión técnica, implementación y salida a producción sin ir moviendo el problema a otra persona."}
           </p>
         </div>
       </Section>
@@ -226,11 +233,15 @@ export function HomePage({ locale }: HomePageProps) {
         title={content.contact.title}
         description={content.contact.description}
       >
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className={`grid gap-4 ${locale === "en" ? "md:grid-cols-3" : "md:grid-cols-1"}`}>
           {[
             { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
-            { label: "Orbytia", href: siteConfig.approvedLinks.orbytia },
-            { label: locale === "en" ? "Contact" : "Contacto", href: getLocalizedPath(locale, "contact") }
+            ...(locale === "en"
+              ? [{ label: "Orbytia", href: siteConfig.approvedLinks.orbytia }]
+              : []),
+            ...(locale === "en"
+              ? [{ label: locale === "en" ? "Contact" : "Contacto", href: getLocalizedPath(locale, "contact") }]
+              : [])
           ].map((item) => (
             <Link
               key={item.label}

--- a/portfolio-v2/src/components/pages/work-page.tsx
+++ b/portfolio-v2/src/components/pages/work-page.tsx
@@ -17,6 +17,17 @@ export function WorkPage({ locale }: WorkPageProps) {
     locale === "en"
       ? "Private production work and product work, written with technical context, ownership and observable outcomes."
       : "Trabajo privado en producción y trabajo de producto, explicado con contexto técnico, responsabilidad técnica y resultados observables.";
+  const categories =
+    locale === "en"
+      ? Object.entries(categoryLabels)
+      : Object.entries(categoryLabels).filter(([key]) => key !== "ecosystem");
+  const studies =
+    locale === "en"
+      ? caseStudies
+      : [
+          ...caseStudies.filter((study) => study.category === "client-work"),
+          ...caseStudies.filter((study) => study.slug === "verifiko")
+        ];
 
   return (
     <SiteFrame locale={locale}>
@@ -26,7 +37,7 @@ export function WorkPage({ locale }: WorkPageProps) {
         description={description}
       >
         <div className="flex flex-wrap gap-2.5 sm:gap-3">
-          {Object.entries(categoryLabels).map(([key, label]) => (
+          {categories.map(([key, label]) => (
             <span
               key={key}
               className="rounded-full border border-white/10 bg-white/[0.03] px-3.5 py-1.5 text-[0.66rem] font-semibold uppercase tracking-[0.22em] text-white/52 sm:px-4 sm:py-2 sm:text-[0.68rem]"
@@ -36,7 +47,7 @@ export function WorkPage({ locale }: WorkPageProps) {
           ))}
         </div>
         <div className="grid gap-6 xl:grid-cols-2">
-          {caseStudies.map((study) => (
+          {studies.map((study) => (
             <CaseCard key={study.slug} locale={locale} study={study} />
           ))}
         </div>

--- a/portfolio-v2/src/components/site/footer.tsx
+++ b/portfolio-v2/src/components/site/footer.tsx
@@ -12,7 +12,7 @@ export function Footer({ locale }: FooterProps) {
   const bottomLine =
     locale === "en"
       ? "Ticketing portals, integrations, backend systems and operational product work."
-      : "Portales de ticketing, integraciones, sistemas backend y trabajo de producto orientado a operación.";
+      : "Integraciones, sistemas backend y trabajo de producto en producción.";
 
   return (
     <footer className="border-t border-white/8 bg-slate-950/92">
@@ -24,12 +24,12 @@ export function Footer({ locale }: FooterProps) {
           <h2 className="max-w-lg text-[1.72rem] font-semibold leading-[1.08] tracking-[-0.04em] text-white sm:text-[1.86rem]">
             {locale === "en"
               ? "Software engineer for ticketing portals, integrations and backend systems."
-              : "Ingeniero de software para portales de ticketing, integraciones y sistemas backend."}
+              : "Ingeniero de software para integraciones, sistemas backend y producto en producción."}
           </h2>
           <p className="max-w-lg text-[0.95rem] leading-8 text-white/58">
             {locale === "en"
               ? "Open to engineering roles and technical conversations."
-              : "Abierto a roles de ingeniería y conversaciones técnicas."}
+              : "Abierto a oportunidades de ingeniería y conversaciones técnicas."}
           </p>
         </div>
         <div className="space-y-5 lg:pl-2">
@@ -54,11 +54,13 @@ export function Footer({ locale }: FooterProps) {
                 LinkedIn
               </Link>
             </li>
-            <li>
-              <Link href={siteConfig.approvedLinks.orbytia} className="inline-flex transition hover:text-white">
-                Orbytia
-              </Link>
-            </li>
+            {locale === "en" ? (
+              <li>
+                <Link href={siteConfig.approvedLinks.orbytia} className="inline-flex transition hover:text-white">
+                  Orbytia
+                </Link>
+              </li>
+            ) : null}
             <li>
               <Link href={siteConfig.approvedLinks.github} className="inline-flex transition hover:text-white">
                 GitHub

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -30,7 +30,7 @@ export const siteConfig = {
   name: "Hernán Bonavota",
   description: {
     en: "Software engineer focused on ticketing portals, integrations, backend systems and operational product work.",
-    es: "Ingeniero de software enfocado en portales de ticketing, integraciones, sistemas backend y trabajo de producto orientado a operación."
+    es: "Ingeniero de software enfocado en integraciones, sistemas backend y trabajo de producto en producción."
   },
   domain: "https://hbonavota.com",
   portfolioDomains: ["https://hbonavota.com/", "https://hbonavota.es/"],
@@ -62,7 +62,6 @@ export const navigation = {
   es: [
     { label: "Trabajo", href: "/es/trabajo" },
     { label: "Sobre mí", href: "/es/sobre-mi" },
-    { label: "Orbytia", href: "/es/orbytia" },
     { label: "Contacto", href: "/es/contacto" }
   ]
 } as const;
@@ -117,29 +116,29 @@ export const homeContent = {
   es: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Ingeniero de software para portales de ticketing, integraciones y sistemas backend.",
+      title: "Ingeniero de software para integraciones, sistemas backend y producto en producción.",
       description:
-        "Trabajo sobre ticketing, validación de socios, flujos de datos e infraestructura donde un fallo tiene coste operativo directo.",
+        "Trabajo sobre validación, concurrencia, flujos de datos, infraestructura e implementación de punta a punta cuando el fallo tiene impacto directo en operación.",
       primaryCta: { label: "Ver trabajo", href: "/es/trabajo" },
-      secondaryCta: { label: "Contacto", href: "/es/contacto" }
+      secondaryCta: { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin }
     },
     selectedWork: {
       eyebrow: "Trabajo destacado",
       title: "Casos de trabajo en producción.",
       description:
-        "Ticketing, validación de socios, control de concurrencia y producto, con alcance y decisiones concretas."
+        "Integración, validación, concurrencia y producto, con alcance, restricciones y decisiones concretas."
     },
     capabilities: {
       eyebrow: "Qué cubro",
       title: "Lo que suelo cubrir.",
       description:
-        "Portales de ticketing, integraciones, validación de datos, WordPress, AWS e implementación de punta a punta."
+        "Integraciones, validación de datos, WordPress, AWS e implementación de punta a punta."
     },
     experience: {
       eyebrow: "Trabajo actual",
       title: "Alcance actual en producción.",
       description:
-        "Hoy trabajo con ticketing, validación de socios, colas, formularios e infraestructura."
+        "Hoy trabajo con validación de socios, colas, formularios, integraciones e infraestructura."
     },
     ecosystem: {
       eyebrow: "Contexto profesional",
@@ -151,13 +150,13 @@ export const homeContent = {
       eyebrow: "Sobre mí",
       title: "Cómo opero.",
       description:
-        "Entrega de punta a punta, criterio técnico y trabajo directo con clientes y equipos."
+        "Criterio técnico, entrega de punta a punta y trato directo con cliente."
     },
     contact: {
       eyebrow: "Contacto",
-      title: "Abierto a roles de ingeniería y conversaciones técnicas.",
+      title: "Abierto a oportunidades de ingeniería y conversaciones técnicas.",
       description:
-        "LinkedIn es la mejor vía de primer contacto para recruiters y hiring managers. Orbytia queda solo como canal separado para consultas de servicios."
+        "LinkedIn es la mejor vía de primer contacto para recruiters y hiring managers."
     }
   }
 } as const;
@@ -183,8 +182,8 @@ export const capabilities = {
   ],
   es: [
     {
-      title: "Portales de ticketing y socios",
-      text: "Venta, validación, acceso y flujos de cuenta ligados a la operativa del club."
+      title: "Portales, acceso y validación",
+      text: "Venta, validación, acceso y flujos de cuenta ligados a operación."
     },
     {
       title: "Integraciones y validación de datos",
@@ -209,7 +208,7 @@ export const professionalExperience = {
   },
   summary: {
     en: "At Rezolve I work on ticketing portals, member validation, queueing, data update flows and AWS-backed operations for clubs in professional football.",
-    es: "En Rezolve trabajo sobre portales de ticketing, validación de socios, colas, flujos de actualización de datos y operación sobre AWS para clubes de fútbol profesional."
+    es: "En Rezolve trabajo sobre portales, validación de socios, colas, flujos de actualización de datos, integraciones y operación sobre AWS para clubes de fútbol profesional."
   },
   notes: {
     en: [
@@ -322,9 +321,9 @@ export const contactPage = {
       "For roles and technical conversations, LinkedIn is the best first contact. Orbytia is only for service enquiries."
   },
   es: {
-    title: "Abierto a roles de ingeniería y conversaciones técnicas.",
+    title: "Abierto a oportunidades de ingeniería y conversaciones técnicas.",
     description:
-      "Para roles y conversaciones técnicas, LinkedIn es el mejor primer contacto. Orbytia queda solo para consultas de servicios."
+      "Para oportunidades y conversaciones técnicas, LinkedIn es el mejor primer contacto."
   }
 } as const;
 


### PR DESCRIPTION
## Context

The Spanish version of the portfolio was still carrying unnecessary context and mixed positioning between personal profile and consulting (Orbytia), which diluted the main goal of the site: positioning for hiring.

This refactor focuses on removing that friction and clarifying the narrative towards a recruiter / hiring manager audience.

## What changed

- Removed Orbytia from the main user flow (navigation, contact, footer and home context)
- Simplified the homepage structure to prioritize:
  - Personal positioning
  - Real production case studies
  - Direct contact path
- Reduced over-reliance on "ticketing" as the main positioning label
- Strengthened copy towards:
  - integrations
  - backend systems
  - validation
  - concurrency
  - production environments
- Updated metadata in Spanish to align with the new positioning
- Adjusted contact flow to remove unnecessary intermediate steps

## Result

The Spanish experience is now:

1. More focused
2. More direct
3. Clearly oriented to hiring instead of services
4. Easier to scan in <30 seconds

## Notes

- No functional logic changes
- No design system changes
- Purely structural + editorial refactor

## Next steps (planned)

- Further reduce friction in contact flow (possibly direct external CTA)
- Rebalance Verifiko visibility vs core case studies
- Tighten "About" section (shorter, sharper)