### PR TITLE
refactor(portfolio): simplify spanish home and tighten positioning

### DIFF
--- a/portfolio-v2/next-env.d.ts
+++ b/portfolio-v2/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/portfolio-v2/src/app/es/page.tsx
+++ b/portfolio-v2/src/app/es/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es",
   title: "Hernán Bonavota",
-  description: "Ingeniero de software enfocado en integraciones, backend, validación y trabajo de producto en producción."
+  description: "Ingeniero de software especializado en backend e integraciones."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/es/trabajo/page.tsx
+++ b/portfolio-v2/src/app/es/trabajo/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "es",
   pathname: "/es/trabajo",
   title: "Trabajo",
-  description: "Casos sobre validación, concurrencia, integraciones y producto en producción."
+  description: "Casos de backend, integraciones, validación y concurrencia."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/components/pages/contact-page.tsx
+++ b/portfolio-v2/src/components/pages/contact-page.tsx
@@ -35,12 +35,14 @@ export function ContactPage({ locale }: ContactPageProps) {
         title={content.title}
         description={content.description}
       >
-        <div className={`grid gap-5 ${locale === "en" ? "md:grid-cols-2 xl:grid-cols-2" : "md:grid-cols-1 xl:grid-cols-1"}`}>
+        <div className={locale === "en" ? "grid gap-5 md:grid-cols-2 xl:grid-cols-2" : "max-w-lg"}>
           {links.map((item) => (
             <Link
               key={item.href}
               href={item.href}
-              className="surface-panel flex h-full min-h-[12.75rem] flex-col justify-between p-[1.625rem] transition hover:border-cyan-200/28 hover:bg-white/[0.06] md:min-h-[13.5rem] md:p-8"
+              className={`surface-panel flex h-full flex-col justify-between p-[1.625rem] transition hover:border-cyan-200/28 hover:bg-white/[0.06] md:p-8 ${
+                locale === "en" ? "min-h-[12.75rem] md:min-h-[13.5rem]" : "min-h-[9rem]"
+              }`}
             >
               <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-white/42">
                 {item.kicker}

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -20,142 +20,206 @@ type HomePageProps = {
 
 export function HomePage({ locale }: HomePageProps) {
   const content = homeContent[locale];
+  const isSpanish = locale === "es";
   const featured =
-    locale === "en"
-      ? caseStudies.filter((study) => study.featured)
-      : caseStudies.filter((study) => study.featured && study.category === "client-work");
+    isSpanish
+      ? caseStudies.filter((study) => study.featured && study.category === "client-work")
+      : caseStudies.filter((study) => study.featured);
 
   return (
     <SiteFrame locale={locale}>
-      <section className="grid gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:items-end lg:gap-16">
-        <div className="space-y-9 pb-2 lg:space-y-10">
-          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.34em] text-cyan-200/72">
-            {content.hero.eyebrow}
-          </p>
-          <div className="space-y-7 lg:space-y-8">
-            <h1 className="max-w-5xl text-[3.25rem] font-semibold leading-[0.94] tracking-tight text-white sm:text-[4.4rem] lg:text-[5.95rem]">
-              {content.hero.title}
-            </h1>
-            <p className="max-w-[43rem] text-[1.05rem] leading-8 text-white/66 sm:text-[1.2rem] sm:leading-9">
-              {content.hero.description}
+      {isSpanish ? (
+        <div className="space-y-18 lg:space-y-20">
+          <section className="max-w-4xl space-y-6 lg:space-y-7">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.34em] text-cyan-200/72">
+              {content.hero.eyebrow}
             </p>
-          </div>
-          <div className="flex flex-wrap gap-3 pt-1.5 lg:gap-4 lg:pt-2">
-            <Link
-              href={content.hero.primaryCta.href}
-              className="rounded-full border border-cyan-300/24 bg-cyan-300/10 px-5.5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16 sm:px-6 sm:py-3.5"
-            >
-              {content.hero.primaryCta.label}
-            </Link>
-            <Link
-              href={content.hero.secondaryCta.href}
-              className="rounded-full border border-white/10 px-5.5 py-3 text-sm font-semibold text-white/84 transition hover:border-white/22 hover:text-white sm:px-6 sm:py-3.5"
-            >
-              {content.hero.secondaryCta.label}
-            </Link>
-          </div>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-              {locale === "en" ? "Professional profile" : "Perfil profesional"}
-            </p>
-            <h2 className="mt-5 text-[1.9rem] font-semibold text-white">Hernán Bonavota</h2>
-            <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
-              {locale === "en"
-                ? "Ticketing, integrations and backend for production portals."
-                : "Integraciones, backend y producto en producción."}
-            </p>
-          </div>
-          {locale === "en" ? (
-            <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-                {locale === "en" ? "Secondary context" : "Contexto secundario"}
-              </p>
-              <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
-                {locale === "en" ? "Orbytia" : "Orbytia"}
-              </h2>
-              <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
-                {locale === "en"
-                  ? "Separate consulting context for selected client work."
-                  : "Contexto de consultoría separado para parte del trabajo con clientes."}
+            <div className="space-y-5 lg:space-y-6">
+              <h1 className="max-w-4xl text-[3rem] font-semibold leading-[0.96] tracking-tight text-white sm:text-[3.9rem] lg:text-[4.65rem]">
+                {content.hero.title}
+              </h1>
+              <p className="max-w-[38rem] text-[1rem] leading-7 text-white/68 sm:text-[1.08rem] sm:leading-8">
+                {content.hero.description}
               </p>
             </div>
-          ) : null}
-          <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">
-              {locale === "en" ? "Own product" : "Producto propio"}
-            </p>
-            <h2 className="mt-5 text-[2.15rem] font-semibold text-white">
-              {locale === "en" ? "Verifiko" : "Verifiko"}
-            </h2>
-            <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
-              {locale === "en"
-                ? "Own product and a concrete example of product engineering outside client delivery."
-                : "Producto propio y ejemplo complementario de trabajo de producto fuera de la entrega a clientes."}
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <Section
-        id="selected-work"
-        eyebrow={content.selectedWork.eyebrow}
-        title={content.selectedWork.title}
-        description={content.selectedWork.description}
-      >
-        <div className="grid gap-6 xl:grid-cols-2">
-          {featured.map((study) => (
-            <CaseCard key={study.slug} locale={locale} study={study} />
-          ))}
-        </div>
-      </Section>
-
-      <Section
-        id="capabilities"
-        eyebrow={content.capabilities.eyebrow}
-        title={content.capabilities.title}
-        description={content.capabilities.description}
-      >
-        <div className="grid gap-5 lg:grid-cols-2">
-          {capabilities[locale].map((item) => (
-            <div key={item.title} className="surface-panel rounded-[2.1rem] p-[1.625rem] md:p-8">
-              <h3 className="text-[1.45rem] font-semibold text-white">{item.title}</h3>
-              <p className="mt-4 text-[0.98rem] leading-8 text-white/64">{item.text}</p>
+            <div className="flex flex-wrap gap-3 pt-0.5">
+              <Link
+                href={content.hero.primaryCta.href}
+                className="rounded-full border border-cyan-300/24 bg-cyan-300/10 px-5.5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16 sm:px-6 sm:py-3.5"
+              >
+                {content.hero.primaryCta.label}
+              </Link>
+              <Link
+                href={content.hero.secondaryCta.href}
+                className="rounded-full border border-white/10 px-5.5 py-3 text-sm font-semibold text-white/84 transition hover:border-white/22 hover:text-white sm:px-6 sm:py-3.5"
+              >
+                {content.hero.secondaryCta.label}
+              </Link>
             </div>
-          ))}
-        </div>
-      </Section>
+          </section>
 
-      <Section
-        id="experience"
-        eyebrow={content.experience.eyebrow}
-        title={content.experience.title}
-        description={content.experience.description}
-      >
-        <div className="grid gap-6 lg:grid-cols-[0.92fr_1.08fr]">
-          <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-              {locale === "en" ? "Current context" : "Contexto actual"}
-            </p>
-            <h3 className="mt-5 text-[2rem] font-semibold text-white">{professionalExperience.company}</h3>
-            <p className="mt-3 text-sm uppercase tracking-[0.24em] text-cyan-200/72">
-              {professionalExperience.role[locale]}
-            </p>
-            <p className="mt-5 text-[0.98rem] leading-8 text-white/66">{professionalExperience.summary[locale]}</p>
-          </div>
-          <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-            <ul className="space-y-5 text-[0.98rem] leading-8 text-white/68">
-              {professionalExperience.notes[locale].map((item) => (
-                <li key={item} className="flex gap-3">
-                  <span className="mt-3 h-2 w-2 rounded-full bg-cyan-200" aria-hidden="true" />
-                  <span>{item}</span>
-                </li>
+          <Section
+            id="selected-work"
+            eyebrow={content.selectedWork.eyebrow}
+            title={content.selectedWork.title}
+          >
+            <div className="grid gap-6 xl:grid-cols-2">
+              {featured.map((study) => (
+                <CaseCard key={study.slug} locale={locale} study={study} />
               ))}
-            </ul>
-          </div>
+            </div>
+          </Section>
+
+          <Section
+            id="experience"
+            eyebrow={content.experience.eyebrow}
+            title={content.experience.title}
+          >
+            <div className="grid gap-5 lg:grid-cols-[1.02fr_0.98fr]">
+              <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Rezolve</p>
+                <h3 className="mt-5 text-[1.8rem] font-semibold text-white md:text-[1.95rem]">
+                  {professionalExperience.role[locale]}
+                </h3>
+                <p className="mt-5 text-[0.98rem] leading-8 text-white/66">{professionalExperience.summary[locale]}</p>
+              </div>
+              <div className="grid gap-5">
+                <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
+                  <ul className="space-y-4 text-[0.98rem] leading-8 text-white/68">
+                    {professionalExperience.notes[locale].map((item) => (
+                      <li key={item} className="flex gap-3">
+                        <span className="mt-3 h-2 w-2 rounded-full bg-cyan-200" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <Link
+                  href={siteConfig.approvedLinks.linkedin}
+                  className="surface-panel flex min-h-[8.5rem] flex-col justify-between rounded-[2rem] p-6 transition hover:border-cyan-200/30 hover:text-cyan-100 md:p-7"
+                >
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-white/42">
+                    {content.contact.eyebrow}
+                  </p>
+                  <div className="mt-6 flex items-end justify-between gap-4">
+                    <div className="space-y-2">
+                      <h3 className="text-[1.4rem] font-semibold tracking-[-0.04em] text-white md:text-[1.5rem]">
+                        LinkedIn
+                      </h3>
+                      <p className="max-w-md text-sm leading-7 text-white/62">{content.contact.description}</p>
+                    </div>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] text-sm text-white/56">
+                      ↗
+                    </span>
+                  </div>
+                </Link>
+              </div>
+            </div>
+          </Section>
         </div>
-      </Section>
+      ) : (
+        <section className="grid gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:items-end lg:gap-16">
+          <div className="space-y-9 pb-2 lg:space-y-10">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.34em] text-cyan-200/72">
+              {content.hero.eyebrow}
+            </p>
+            <div className="space-y-7 lg:space-y-8">
+              <h1 className="max-w-5xl text-[3.25rem] font-semibold leading-[0.94] tracking-tight text-white sm:text-[4.4rem] lg:text-[5.95rem]">
+                {content.hero.title}
+              </h1>
+              <p className="max-w-[43rem] text-[1.05rem] leading-8 text-white/66 sm:text-[1.2rem] sm:leading-9">
+                {content.hero.description}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 pt-1.5 lg:gap-4 lg:pt-2">
+              <Link
+                href={content.hero.primaryCta.href}
+                className="rounded-full border border-cyan-300/24 bg-cyan-300/10 px-5.5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16 sm:px-6 sm:py-3.5"
+              >
+                {content.hero.primaryCta.label}
+              </Link>
+              <Link
+                href={content.hero.secondaryCta.href}
+                className="rounded-full border border-white/10 px-5.5 py-3 text-sm font-semibold text-white/84 transition hover:border-white/22 hover:text-white sm:px-6 sm:py-3.5"
+              >
+                {content.hero.secondaryCta.label}
+              </Link>
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
+                {locale === "en" ? "Professional profile" : "Perfil profesional"}
+              </p>
+              <h2 className="mt-5 text-[1.9rem] font-semibold text-white">Hernán Bonavota</h2>
+              <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
+                Ticketing, integrations and backend for production portals.
+              </p>
+            </div>
+            {locale === "en" ? (
+              <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
+                  {locale === "en" ? "Secondary context" : "Contexto secundario"}
+                </p>
+                <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
+                  {locale === "en" ? "Orbytia" : "Orbytia"}
+                </h2>
+                <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
+                  {locale === "en"
+                    ? "Separate consulting context for selected client work."
+                    : "Contexto de consultoría separado para parte del trabajo con clientes."}
+                </p>
+              </div>
+            ) : null}
+            <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">
+                {locale === "en" ? "Own product" : "Producto propio"}
+              </p>
+              <h2 className="mt-5 text-[2.15rem] font-semibold text-white">
+                {locale === "en" ? "Verifiko" : "Verifiko"}
+              </h2>
+              <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
+                {locale === "en"
+                  ? "Own product and a concrete example of product engineering outside client delivery."
+                  : "Producto propio y ejemplo complementario de trabajo de producto fuera de la entrega a clientes."}
+              </p>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {isSpanish ? null : (
+        <Section
+          id="selected-work"
+          eyebrow={content.selectedWork.eyebrow}
+          title={content.selectedWork.title}
+          description={content.selectedWork.description}
+        >
+          <div className="grid gap-6 xl:grid-cols-2">
+            {featured.map((study) => (
+              <CaseCard key={study.slug} locale={locale} study={study} />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {isSpanish ? null : (
+        <Section
+          id="capabilities"
+          eyebrow={content.capabilities.eyebrow}
+          title={content.capabilities.title}
+          description={content.capabilities.description}
+        >
+          <div className="grid gap-5 lg:grid-cols-2">
+            {capabilities[locale].map((item) => (
+              <div key={item.title} className="surface-panel rounded-[2.1rem] p-[1.625rem] md:p-8">
+                <h3 className="text-[1.45rem] font-semibold text-white">{item.title}</h3>
+                <p className="mt-4 text-[0.98rem] leading-8 text-white/64">{item.text}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
 
       {locale === "en" ? (
         <Section
@@ -207,52 +271,86 @@ export function HomePage({ locale }: HomePageProps) {
         </Section>
       ) : null}
 
-      <Section
-        id="about"
-        eyebrow={content.about.eyebrow}
-        title={content.about.title}
-        description={content.about.description}
-      >
-        <div className="max-w-4xl space-y-7 text-[1.02rem] leading-8 text-white/68">
-          <p>
-            {locale === "en"
-              ? "Most of my work sits where the business need is already visible but the implementation still needs definition, ownership and execution."
-              : "Suelo aportar más cuando la necesidad de negocio ya está clara pero todavía hace falta definir, decidir e implementar bien."}
-          </p>
-          <p>
-            {locale === "en"
-              ? "That usually means moving between client conversations, technical decisions, implementation and release without handing the problem off."
-              : "Eso suele implicar moverme entre conversación con cliente, decisión técnica, implementación y salida a producción sin ir moviendo el problema a otra persona."}
-          </p>
-        </div>
-      </Section>
+      {locale === "en" ? (
+        <>
+          <Section
+            id="experience"
+            eyebrow={content.experience.eyebrow}
+            title={content.experience.title}
+            description={content.experience.description}
+          >
+            <div className="grid gap-6 lg:grid-cols-[0.92fr_1.08fr]">
+              <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
+                  {locale === "en" ? "Current context" : "Contexto actual"}
+                </p>
+                <h3 className="mt-5 text-[2rem] font-semibold text-white">{professionalExperience.company}</h3>
+                <p className="mt-3 text-sm uppercase tracking-[0.24em] text-cyan-200/72">
+                  {professionalExperience.role[locale]}
+                </p>
+                <p className="mt-5 text-[0.98rem] leading-8 text-white/66">{professionalExperience.summary[locale]}</p>
+              </div>
+              <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
+                <ul className="space-y-5 text-[0.98rem] leading-8 text-white/68">
+                  {professionalExperience.notes[locale].map((item) => (
+                    <li key={item} className="flex gap-3">
+                      <span className="mt-3 h-2 w-2 rounded-full bg-cyan-200" aria-hidden="true" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </Section>
 
-      <Section
-        id="contact"
-        eyebrow={content.contact.eyebrow}
-        title={content.contact.title}
-        description={content.contact.description}
-      >
-        <div className={`grid gap-4 ${locale === "en" ? "md:grid-cols-3" : "md:grid-cols-1"}`}>
-          {[
-            { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
-            ...(locale === "en"
-              ? [{ label: "Orbytia", href: siteConfig.approvedLinks.orbytia }]
-              : []),
-            ...(locale === "en"
-              ? [{ label: locale === "en" ? "Contact" : "Contacto", href: getLocalizedPath(locale, "contact") }]
-              : [])
-          ].map((item) => (
-            <Link
-              key={item.label}
-              href={item.href}
-              className="surface-panel flex min-h-[8rem] items-end rounded-[2rem] p-[1.625rem] text-lg font-semibold text-white transition hover:border-cyan-200/30 hover:text-cyan-100 md:min-h-[8.5rem] md:p-8"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </div>
-      </Section>
+          <Section
+            id="about"
+            eyebrow={content.about.eyebrow}
+            title={content.about.title}
+            description={content.about.description}
+          >
+            <div className="max-w-4xl space-y-7 text-[1.02rem] leading-8 text-white/68">
+              <p>
+                {locale === "en"
+                  ? "Most of my work sits where the business need is already visible but the implementation still needs definition, ownership and execution."
+                  : "Suelo aportar más cuando la necesidad de negocio ya está clara pero todavía hace falta definir, decidir e implementar bien."}
+              </p>
+              <p>
+                {locale === "en"
+                  ? "That usually means moving between client conversations, technical decisions, implementation and release without handing the problem off."
+                  : "Eso suele implicar moverme entre conversación con cliente, decisión técnica, implementación y salida a producción sin ir moviendo el problema a otra persona."}
+              </p>
+            </div>
+          </Section>
+
+          <Section
+            id="contact"
+            eyebrow={content.contact.eyebrow}
+            title={content.contact.title}
+            description={content.contact.description}
+          >
+            <div className={`grid gap-4 ${locale === "en" ? "md:grid-cols-3" : "md:grid-cols-1"}`}>
+              {[
+                { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
+                ...(locale === "en"
+                  ? [{ label: "Orbytia", href: siteConfig.approvedLinks.orbytia }]
+                  : []),
+                ...(locale === "en"
+                  ? [{ label: locale === "en" ? "Contact" : "Contacto", href: getLocalizedPath(locale, "contact") }]
+                  : [])
+              ].map((item) => (
+                <Link
+                  key={item.label}
+                  href={item.href}
+                  className="surface-panel flex min-h-[8rem] items-end rounded-[2rem] p-[1.625rem] text-lg font-semibold text-white transition hover:border-cyan-200/30 hover:text-cyan-100 md:min-h-[8.5rem] md:p-8"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </Section>
+        </>
+      ) : null}
     </SiteFrame>
   );
 }

--- a/portfolio-v2/src/components/pages/work-page.tsx
+++ b/portfolio-v2/src/components/pages/work-page.tsx
@@ -16,7 +16,7 @@ export function WorkPage({ locale }: WorkPageProps) {
   const description =
     locale === "en"
       ? "Private production work and product work, written with technical context, ownership and observable outcomes."
-      : "Trabajo privado en producción y trabajo de producto, explicado con contexto técnico, responsabilidad técnica y resultados observables.";
+      : "Casos de backend, integraciones, validación y concurrencia explicados con contexto técnico y resultados observables.";
   const categories =
     locale === "en"
       ? Object.entries(categoryLabels)

--- a/portfolio-v2/src/components/site/footer.tsx
+++ b/portfolio-v2/src/components/site/footer.tsx
@@ -12,7 +12,7 @@ export function Footer({ locale }: FooterProps) {
   const bottomLine =
     locale === "en"
       ? "Ticketing portals, integrations, backend systems and operational product work."
-      : "Integraciones, sistemas backend y trabajo de producto en producción.";
+      : "Backend, integraciones y flujos críticos en producción.";
 
   return (
     <footer className="border-t border-white/8 bg-slate-950/92">
@@ -24,7 +24,7 @@ export function Footer({ locale }: FooterProps) {
           <h2 className="max-w-lg text-[1.72rem] font-semibold leading-[1.08] tracking-[-0.04em] text-white sm:text-[1.86rem]">
             {locale === "en"
               ? "Software engineer for ticketing portals, integrations and backend systems."
-              : "Ingeniero de software para integraciones, sistemas backend y producto en producción."}
+              : "Ingeniero de software especializado en backend e integraciones."}
           </h2>
           <p className="max-w-lg text-[0.95rem] leading-8 text-white/58">
             {locale === "en"

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -30,7 +30,7 @@ export const siteConfig = {
   name: "Hernán Bonavota",
   description: {
     en: "Software engineer focused on ticketing portals, integrations, backend systems and operational product work.",
-    es: "Ingeniero de software enfocado en integraciones, sistemas backend y trabajo de producto en producción."
+    es: "Ingeniero de software especializado en backend e integraciones."
   },
   domain: "https://hbonavota.com",
   portfolioDomains: ["https://hbonavota.com/", "https://hbonavota.es/"],
@@ -116,29 +116,29 @@ export const homeContent = {
   es: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Ingeniero de software para integraciones, sistemas backend y producto en producción.",
+      title: "Ingeniero de software especializado en backend e integraciones.",
       description:
-        "Trabajo sobre validación, concurrencia, flujos de datos, infraestructura e implementación de punta a punta cuando el fallo tiene impacto directo en operación.",
+        "Trabajo en validación, concurrencia y flujos críticos donde un fallo impacta la operación.",
       primaryCta: { label: "Ver trabajo", href: "/es/trabajo" },
       secondaryCta: { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin }
     },
     selectedWork: {
       eyebrow: "Trabajo destacado",
-      title: "Casos de trabajo en producción.",
+      title: "Casos principales.",
       description:
-        "Integración, validación, concurrencia y producto, con alcance, restricciones y decisiones concretas."
+        "Concurrencia, validación e integraciones con decisiones técnicas visibles."
     },
     capabilities: {
       eyebrow: "Qué cubro",
-      title: "Lo que suelo cubrir.",
+      title: "Capacidades técnicas.",
       description:
-        "Integraciones, validación de datos, WordPress, AWS e implementación de punta a punta."
+        "Integraciones, validación, WordPress y AWS en contexto operativo."
     },
     experience: {
-      eyebrow: "Trabajo actual",
-      title: "Alcance actual en producción.",
+      eyebrow: "Contexto actual",
+      title: "Experiencia actual.",
       description:
-        "Hoy trabajo con validación de socios, colas, formularios, integraciones e infraestructura."
+        "Ticketing, validación de socios e integraciones sobre AWS."
     },
     ecosystem: {
       eyebrow: "Contexto profesional",
@@ -154,9 +154,9 @@ export const homeContent = {
     },
     contact: {
       eyebrow: "Contacto",
-      title: "Abierto a oportunidades de ingeniería y conversaciones técnicas.",
+      title: "Contacto directo.",
       description:
-        "LinkedIn es la mejor vía de primer contacto para recruiters y hiring managers."
+        "LinkedIn es la vía directa para recruiters, hiring managers y leads técnicos."
     }
   }
 } as const;
@@ -208,7 +208,7 @@ export const professionalExperience = {
   },
   summary: {
     en: "At Rezolve I work on ticketing portals, member validation, queueing, data update flows and AWS-backed operations for clubs in professional football.",
-    es: "En Rezolve trabajo sobre portales, validación de socios, colas, flujos de actualización de datos, integraciones y operación sobre AWS para clubes de fútbol profesional."
+    es: "En Rezolve trabajo en ticketing, validación de socios e integraciones sobre AWS para clubes de fútbol profesional."
   },
   notes: {
     en: [
@@ -321,9 +321,9 @@ export const contactPage = {
       "For roles and technical conversations, LinkedIn is the best first contact. Orbytia is only for service enquiries."
   },
   es: {
-    title: "Abierto a oportunidades de ingeniería y conversaciones técnicas.",
+    title: "LinkedIn para primer contacto.",
     description:
-      "Para oportunidades y conversaciones técnicas, LinkedIn es el mejor primer contacto."
+      "La vía directa para recruiters, hiring managers y leads técnicos."
   }
 } as const;
 


### PR DESCRIPTION
## Summary
- simplify the Spanish home to a shorter recruiter-first narrative
- replace the old hero claim with a clearer backend/integrations positioning
- remove low-value repeated sections from the Spanish home
- make client case studies the main proof on the page
- compact Spanish contact and keep LinkedIn as the direct recruiting path
- align footer and Spanish metadata with the new positioning

## Validation
- npm run typecheck ✅
- npm run build ✅