### PR TITLE
refactor(portfolio): align english version with recruiter-first struc…

### DIFF
--- a/portfolio-v2/src/app/contact/page.tsx
+++ b/portfolio-v2/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/contact",
   title: "Contact",
-  description: "Best first contact for recruiters, hiring managers and technical conversations."
+  description: "Direct contact for recruiters, hiring managers, and tech leads."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/page.tsx
+++ b/portfolio-v2/src/app/page.tsx
@@ -5,7 +5,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/",
   title: "Hernán Bonavota",
-  description: "Software engineer focused on ticketing portals, integrations, backend systems and operational product work."
+  description: "Software engineer specialized in backend and integrations."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/app/work/page.tsx
+++ b/portfolio-v2/src/app/work/page.tsx
@@ -6,7 +6,7 @@ export const metadata = buildMetadata({
   locale: "en",
   pathname: "/work",
   title: "Work",
-  description: "Case studies on ticketing, member validation, concurrency control and product work."
+  description: "Case studies on backend systems, integrations, validation, and concurrency."
 });
 
 export default function Page() {

--- a/portfolio-v2/src/components/pages/contact-page.tsx
+++ b/portfolio-v2/src/components/pages/contact-page.tsx
@@ -16,16 +16,7 @@ export function ContactPage({ locale }: ContactPageProps) {
       label: "LinkedIn",
       href: siteConfig.approvedLinks.linkedin,
       kicker: locale === "en" ? "Direct message" : "Mensaje directo"
-    },
-    ...(locale === "en"
-      ? [
-          {
-            label: "Orbytia",
-            href: siteConfig.approvedLinks.orbytia,
-            kicker: locale === "en" ? "Services only" : "Solo servicios"
-          }
-        ]
-      : [])
+    }
   ];
 
   return (
@@ -35,14 +26,12 @@ export function ContactPage({ locale }: ContactPageProps) {
         title={content.title}
         description={content.description}
       >
-        <div className={locale === "en" ? "grid gap-5 md:grid-cols-2 xl:grid-cols-2" : "max-w-lg"}>
+        <div className="max-w-lg">
           {links.map((item) => (
             <Link
               key={item.href}
               href={item.href}
-              className={`surface-panel flex h-full flex-col justify-between p-[1.625rem] transition hover:border-cyan-200/28 hover:bg-white/[0.06] md:p-8 ${
-                locale === "en" ? "min-h-[12.75rem] md:min-h-[13.5rem]" : "min-h-[9rem]"
-              }`}
+              className="surface-panel flex h-full min-h-[9rem] flex-col justify-between p-[1.625rem] transition hover:border-cyan-200/28 hover:bg-white/[0.06] md:p-8"
             >
               <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-white/42">
                 {item.kicker}

--- a/portfolio-v2/src/components/pages/home-page.tsx
+++ b/portfolio-v2/src/components/pages/home-page.tsx
@@ -1,14 +1,6 @@
 import Link from "next/link";
 
-import {
-  capabilities,
-  caseStudies,
-  homeContent,
-  Locale,
-  professionalExperience,
-  siteConfig
-} from "@/content/site";
-import { getLocalizedPath } from "@/lib/i18n";
+import { caseStudies, homeContent, Locale, professionalExperience, siteConfig } from "@/content/site";
 
 import { CaseCard } from "@/components/site/case-card";
 import { Section } from "@/components/site/section";
@@ -20,180 +12,43 @@ type HomePageProps = {
 
 export function HomePage({ locale }: HomePageProps) {
   const content = homeContent[locale];
-  const isSpanish = locale === "es";
-  const featured =
-    isSpanish
-      ? caseStudies.filter((study) => study.featured && study.category === "client-work")
-      : caseStudies.filter((study) => study.featured);
+  const featured = caseStudies.filter((study) => study.featured && study.category === "client-work");
 
   return (
     <SiteFrame locale={locale}>
-      {isSpanish ? (
-        <div className="space-y-18 lg:space-y-20">
-          <section className="max-w-4xl space-y-6 lg:space-y-7">
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.34em] text-cyan-200/72">
-              {content.hero.eyebrow}
+      <div className="space-y-18 lg:space-y-20">
+        <section className="max-w-4xl space-y-6 lg:space-y-7">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.34em] text-cyan-200/72">
+            {content.hero.eyebrow}
+          </p>
+          <div className="space-y-5 lg:space-y-6">
+            <h1 className="max-w-4xl text-[3rem] font-semibold leading-[0.96] tracking-tight text-white sm:text-[3.9rem] lg:text-[4.65rem]">
+              {content.hero.title}
+            </h1>
+            <p className="max-w-[38rem] text-[1rem] leading-7 text-white/68 sm:text-[1.08rem] sm:leading-8">
+              {content.hero.description}
             </p>
-            <div className="space-y-5 lg:space-y-6">
-              <h1 className="max-w-4xl text-[3rem] font-semibold leading-[0.96] tracking-tight text-white sm:text-[3.9rem] lg:text-[4.65rem]">
-                {content.hero.title}
-              </h1>
-              <p className="max-w-[38rem] text-[1rem] leading-7 text-white/68 sm:text-[1.08rem] sm:leading-8">
-                {content.hero.description}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3 pt-0.5">
-              <Link
-                href={content.hero.primaryCta.href}
-                className="rounded-full border border-cyan-300/24 bg-cyan-300/10 px-5.5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16 sm:px-6 sm:py-3.5"
-              >
-                {content.hero.primaryCta.label}
-              </Link>
-              <Link
-                href={content.hero.secondaryCta.href}
-                className="rounded-full border border-white/10 px-5.5 py-3 text-sm font-semibold text-white/84 transition hover:border-white/22 hover:text-white sm:px-6 sm:py-3.5"
-              >
-                {content.hero.secondaryCta.label}
-              </Link>
-            </div>
-          </section>
-
-          <Section
-            id="selected-work"
-            eyebrow={content.selectedWork.eyebrow}
-            title={content.selectedWork.title}
-          >
-            <div className="grid gap-6 xl:grid-cols-2">
-              {featured.map((study) => (
-                <CaseCard key={study.slug} locale={locale} study={study} />
-              ))}
-            </div>
-          </Section>
-
-          <Section
-            id="experience"
-            eyebrow={content.experience.eyebrow}
-            title={content.experience.title}
-          >
-            <div className="grid gap-5 lg:grid-cols-[1.02fr_0.98fr]">
-              <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Rezolve</p>
-                <h3 className="mt-5 text-[1.8rem] font-semibold text-white md:text-[1.95rem]">
-                  {professionalExperience.role[locale]}
-                </h3>
-                <p className="mt-5 text-[0.98rem] leading-8 text-white/66">{professionalExperience.summary[locale]}</p>
-              </div>
-              <div className="grid gap-5">
-                <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-                  <ul className="space-y-4 text-[0.98rem] leading-8 text-white/68">
-                    {professionalExperience.notes[locale].map((item) => (
-                      <li key={item} className="flex gap-3">
-                        <span className="mt-3 h-2 w-2 rounded-full bg-cyan-200" aria-hidden="true" />
-                        <span>{item}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <Link
-                  href={siteConfig.approvedLinks.linkedin}
-                  className="surface-panel flex min-h-[8.5rem] flex-col justify-between rounded-[2rem] p-6 transition hover:border-cyan-200/30 hover:text-cyan-100 md:p-7"
-                >
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-white/42">
-                    {content.contact.eyebrow}
-                  </p>
-                  <div className="mt-6 flex items-end justify-between gap-4">
-                    <div className="space-y-2">
-                      <h3 className="text-[1.4rem] font-semibold tracking-[-0.04em] text-white md:text-[1.5rem]">
-                        LinkedIn
-                      </h3>
-                      <p className="max-w-md text-sm leading-7 text-white/62">{content.contact.description}</p>
-                    </div>
-                    <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] text-sm text-white/56">
-                      ↗
-                    </span>
-                  </div>
-                </Link>
-              </div>
-            </div>
-          </Section>
-        </div>
-      ) : (
-        <section className="grid gap-12 lg:grid-cols-[1.08fr_0.92fr] lg:items-end lg:gap-16">
-          <div className="space-y-9 pb-2 lg:space-y-10">
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.34em] text-cyan-200/72">
-              {content.hero.eyebrow}
-            </p>
-            <div className="space-y-7 lg:space-y-8">
-              <h1 className="max-w-5xl text-[3.25rem] font-semibold leading-[0.94] tracking-tight text-white sm:text-[4.4rem] lg:text-[5.95rem]">
-                {content.hero.title}
-              </h1>
-              <p className="max-w-[43rem] text-[1.05rem] leading-8 text-white/66 sm:text-[1.2rem] sm:leading-9">
-                {content.hero.description}
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3 pt-1.5 lg:gap-4 lg:pt-2">
-              <Link
-                href={content.hero.primaryCta.href}
-                className="rounded-full border border-cyan-300/24 bg-cyan-300/10 px-5.5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16 sm:px-6 sm:py-3.5"
-              >
-                {content.hero.primaryCta.label}
-              </Link>
-              <Link
-                href={content.hero.secondaryCta.href}
-                className="rounded-full border border-white/10 px-5.5 py-3 text-sm font-semibold text-white/84 transition hover:border-white/22 hover:text-white sm:px-6 sm:py-3.5"
-              >
-                {content.hero.secondaryCta.label}
-              </Link>
-            </div>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-                {locale === "en" ? "Professional profile" : "Perfil profesional"}
-              </p>
-              <h2 className="mt-5 text-[1.9rem] font-semibold text-white">Hernán Bonavota</h2>
-              <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
-                Ticketing, integrations and backend for production portals.
-              </p>
-            </div>
-            {locale === "en" ? (
-              <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-                  {locale === "en" ? "Secondary context" : "Contexto secundario"}
-                </p>
-                <h2 className="mt-5 text-[1.9rem] font-semibold text-white">
-                  {locale === "en" ? "Orbytia" : "Orbytia"}
-                </h2>
-                <p className="mt-4 text-[0.96rem] leading-7 text-white/62">
-                  {locale === "en"
-                    ? "Separate consulting context for selected client work."
-                    : "Contexto de consultoría separado para parte del trabajo con clientes."}
-                </p>
-              </div>
-            ) : null}
-            <div className="surface-accent rounded-[2.2rem] p-7 md:p-8 sm:col-span-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-100/72">
-                {locale === "en" ? "Own product" : "Producto propio"}
-              </p>
-              <h2 className="mt-5 text-[2.15rem] font-semibold text-white">
-                {locale === "en" ? "Verifiko" : "Verifiko"}
-              </h2>
-              <p className="mt-4 max-w-2xl text-[0.98rem] leading-8 text-white/70">
-                {locale === "en"
-                  ? "Own product and a concrete example of product engineering outside client delivery."
-                  : "Producto propio y ejemplo complementario de trabajo de producto fuera de la entrega a clientes."}
-              </p>
-            </div>
+          <div className="flex flex-wrap gap-3 pt-0.5">
+            <Link
+              href={content.hero.primaryCta.href}
+              className="rounded-full border border-cyan-300/24 bg-cyan-300/10 px-5.5 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16 sm:px-6 sm:py-3.5"
+            >
+              {content.hero.primaryCta.label}
+            </Link>
+            <Link
+              href={content.hero.secondaryCta.href}
+              className="rounded-full border border-white/10 px-5.5 py-3 text-sm font-semibold text-white/84 transition hover:border-white/22 hover:text-white sm:px-6 sm:py-3.5"
+            >
+              {content.hero.secondaryCta.label}
+            </Link>
           </div>
         </section>
-      )}
 
-      {isSpanish ? null : (
         <Section
           id="selected-work"
           eyebrow={content.selectedWork.eyebrow}
           title={content.selectedWork.title}
-          description={content.selectedWork.description}
         >
           <div className="grid gap-6 xl:grid-cols-2">
             {featured.map((study) => (
@@ -201,97 +56,23 @@ export function HomePage({ locale }: HomePageProps) {
             ))}
           </div>
         </Section>
-      )}
 
-      {isSpanish ? null : (
         <Section
-          id="capabilities"
-          eyebrow={content.capabilities.eyebrow}
-          title={content.capabilities.title}
-          description={content.capabilities.description}
+          id="experience"
+          eyebrow={content.experience.eyebrow}
+          title={content.experience.title}
         >
-          <div className="grid gap-5 lg:grid-cols-2">
-            {capabilities[locale].map((item) => (
-              <div key={item.title} className="surface-panel rounded-[2.1rem] p-[1.625rem] md:p-8">
-                <h3 className="text-[1.45rem] font-semibold text-white">{item.title}</h3>
-                <p className="mt-4 text-[0.98rem] leading-8 text-white/64">{item.text}</p>
-              </div>
-            ))}
-          </div>
-        </Section>
-      )}
-
-      {locale === "en" ? (
-        <Section
-          id="ecosystem"
-          eyebrow={content.ecosystem.eyebrow}
-          title={content.ecosystem.title}
-          description={content.ecosystem.description}
-        >
-          <div className="grid gap-6 lg:grid-cols-3">
-            {[
-              {
-                title: "Hernán Bonavota",
-                text:
-                  locale === "en"
-                    ? "Ticketing, integrations and backend for production portals."
-                    : "Ticketing, integraciones y backend para portales en producción.",
-                href: siteConfig.portfolioDomains[0]
-              },
-              {
-                title: "Orbytia",
-                text:
-                  locale === "en"
-                    ? "Secondary consulting context, separate from the main hiring path."
-                    : "Contexto de consultoría secundario, separado de la vía principal de contratación.",
-                href: siteConfig.approvedLinks.orbytia
-              },
-              {
-                title: "Verifiko",
-                text:
-                  locale === "en"
-                    ? "Own product and supporting evidence of product work."
-                    : "Producto propio y evidencia complementaria de trabajo de producto.",
-                href: siteConfig.approvedLinks.verifiko
-              }
-            ].map((item) => (
-              <div key={item.title} className="surface-panel rounded-[2.1rem] p-[1.625rem] md:p-8">
-                <h3 className="text-[1.45rem] font-semibold text-white">{item.title}</h3>
-                <p className="mt-4 text-[0.98rem] leading-8 text-white/64">{item.text}</p>
-                <Link
-                  href={item.href}
-                  className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-cyan-100 hover:text-white"
-                >
-                  {locale === "en" ? "Visit" : "Visitar"}
-                  <span aria-hidden="true">↗</span>
-                </Link>
-              </div>
-            ))}
-          </div>
-        </Section>
-      ) : null}
-
-      {locale === "en" ? (
-        <>
-          <Section
-            id="experience"
-            eyebrow={content.experience.eyebrow}
-            title={content.experience.title}
-            description={content.experience.description}
-          >
-            <div className="grid gap-6 lg:grid-cols-[0.92fr_1.08fr]">
-              <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">
-                  {locale === "en" ? "Current context" : "Contexto actual"}
-                </p>
-                <h3 className="mt-5 text-[2rem] font-semibold text-white">{professionalExperience.company}</h3>
-                <p className="mt-3 text-sm uppercase tracking-[0.24em] text-cyan-200/72">
-                  {professionalExperience.role[locale]}
-                </p>
-                <p className="mt-5 text-[0.98rem] leading-8 text-white/66">{professionalExperience.summary[locale]}</p>
-              </div>
+          <div className="grid gap-5 lg:grid-cols-[1.02fr_0.98fr]">
+            <div className="surface-panel-strong rounded-[2.2rem] p-7 md:p-8">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/48">Rezolve</p>
+              <h3 className="mt-5 text-[1.8rem] font-semibold text-white md:text-[1.95rem]">
+                {professionalExperience.role[locale]}
+              </h3>
+              <p className="mt-5 text-[0.98rem] leading-8 text-white/66">{professionalExperience.summary[locale]}</p>
+            </div>
+            <div className="grid gap-5">
               <div className="surface-panel rounded-[2.2rem] p-7 md:p-8">
-                <ul className="space-y-5 text-[0.98rem] leading-8 text-white/68">
+                <ul className="space-y-4 text-[0.98rem] leading-8 text-white/68">
                   {professionalExperience.notes[locale].map((item) => (
                     <li key={item} className="flex gap-3">
                       <span className="mt-3 h-2 w-2 rounded-full bg-cyan-200" aria-hidden="true" />
@@ -300,57 +81,29 @@ export function HomePage({ locale }: HomePageProps) {
                   ))}
                 </ul>
               </div>
+              <Link
+                href={siteConfig.approvedLinks.linkedin}
+                className="surface-panel flex min-h-[8.5rem] flex-col justify-between rounded-[2rem] p-6 transition hover:border-cyan-200/30 hover:text-cyan-100 md:p-7"
+              >
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-white/42">
+                  {content.contact.eyebrow}
+                </p>
+                <div className="mt-6 flex items-end justify-between gap-4">
+                  <div className="space-y-2">
+                    <h3 className="text-[1.4rem] font-semibold tracking-[-0.04em] text-white md:text-[1.5rem]">
+                      LinkedIn
+                    </h3>
+                    <p className="max-w-md text-sm leading-7 text-white/62">{content.contact.description}</p>
+                  </div>
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] text-sm text-white/56">
+                    ↗
+                  </span>
+                </div>
+              </Link>
             </div>
-          </Section>
-
-          <Section
-            id="about"
-            eyebrow={content.about.eyebrow}
-            title={content.about.title}
-            description={content.about.description}
-          >
-            <div className="max-w-4xl space-y-7 text-[1.02rem] leading-8 text-white/68">
-              <p>
-                {locale === "en"
-                  ? "Most of my work sits where the business need is already visible but the implementation still needs definition, ownership and execution."
-                  : "Suelo aportar más cuando la necesidad de negocio ya está clara pero todavía hace falta definir, decidir e implementar bien."}
-              </p>
-              <p>
-                {locale === "en"
-                  ? "That usually means moving between client conversations, technical decisions, implementation and release without handing the problem off."
-                  : "Eso suele implicar moverme entre conversación con cliente, decisión técnica, implementación y salida a producción sin ir moviendo el problema a otra persona."}
-              </p>
-            </div>
-          </Section>
-
-          <Section
-            id="contact"
-            eyebrow={content.contact.eyebrow}
-            title={content.contact.title}
-            description={content.contact.description}
-          >
-            <div className={`grid gap-4 ${locale === "en" ? "md:grid-cols-3" : "md:grid-cols-1"}`}>
-              {[
-                { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin },
-                ...(locale === "en"
-                  ? [{ label: "Orbytia", href: siteConfig.approvedLinks.orbytia }]
-                  : []),
-                ...(locale === "en"
-                  ? [{ label: locale === "en" ? "Contact" : "Contacto", href: getLocalizedPath(locale, "contact") }]
-                  : [])
-              ].map((item) => (
-                <Link
-                  key={item.label}
-                  href={item.href}
-                  className="surface-panel flex min-h-[8rem] items-end rounded-[2rem] p-[1.625rem] text-lg font-semibold text-white transition hover:border-cyan-200/30 hover:text-cyan-100 md:min-h-[8.5rem] md:p-8"
-                >
-                  {item.label}
-                </Link>
-              ))}
-            </div>
-          </Section>
-        </>
-      ) : null}
+          </div>
+        </Section>
+      </div>
     </SiteFrame>
   );
 }

--- a/portfolio-v2/src/components/pages/work-page.tsx
+++ b/portfolio-v2/src/components/pages/work-page.tsx
@@ -15,19 +15,15 @@ export function WorkPage({ locale }: WorkPageProps) {
       : "Casos con alcance, restricciones y decisiones.";
   const description =
     locale === "en"
-      ? "Private production work and product work, written with technical context, ownership and observable outcomes."
+      ? "Backend, integrations, validation, and concurrency case studies with technical context and observable outcomes."
       : "Casos de backend, integraciones, validación y concurrencia explicados con contexto técnico y resultados observables.";
   const categories =
-    locale === "en"
-      ? Object.entries(categoryLabels)
-      : Object.entries(categoryLabels).filter(([key]) => key !== "ecosystem");
+    Object.entries(categoryLabels).filter(([key]) => key !== "ecosystem");
   const studies =
-    locale === "en"
-      ? caseStudies
-      : [
-          ...caseStudies.filter((study) => study.category === "client-work"),
-          ...caseStudies.filter((study) => study.slug === "verifiko")
-        ];
+    [
+      ...caseStudies.filter((study) => study.category === "client-work"),
+      ...caseStudies.filter((study) => study.slug === "verifiko")
+    ];
 
   return (
     <SiteFrame locale={locale}>

--- a/portfolio-v2/src/components/site/footer.tsx
+++ b/portfolio-v2/src/components/site/footer.tsx
@@ -11,7 +11,7 @@ export function Footer({ locale }: FooterProps) {
   const externalLabel = locale === "en" ? "External" : "Externo";
   const bottomLine =
     locale === "en"
-      ? "Ticketing portals, integrations, backend systems and operational product work."
+      ? "Backend, integrations, and critical production flows."
       : "Backend, integraciones y flujos críticos en producción.";
 
   return (
@@ -23,7 +23,7 @@ export function Footer({ locale }: FooterProps) {
           </p>
           <h2 className="max-w-lg text-[1.72rem] font-semibold leading-[1.08] tracking-[-0.04em] text-white sm:text-[1.86rem]">
             {locale === "en"
-              ? "Software engineer for ticketing portals, integrations and backend systems."
+              ? "Software engineer specialized in backend and integrations."
               : "Ingeniero de software especializado en backend e integraciones."}
           </h2>
           <p className="max-w-lg text-[0.95rem] leading-8 text-white/58">
@@ -54,13 +54,6 @@ export function Footer({ locale }: FooterProps) {
                 LinkedIn
               </Link>
             </li>
-            {locale === "en" ? (
-              <li>
-                <Link href={siteConfig.approvedLinks.orbytia} className="inline-flex transition hover:text-white">
-                  Orbytia
-                </Link>
-              </li>
-            ) : null}
             <li>
               <Link href={siteConfig.approvedLinks.github} className="inline-flex transition hover:text-white">
                 GitHub

--- a/portfolio-v2/src/content/site.ts
+++ b/portfolio-v2/src/content/site.ts
@@ -29,7 +29,7 @@ export type CaseStudy = {
 export const siteConfig = {
   name: "Hernán Bonavota",
   description: {
-    en: "Software engineer focused on ticketing portals, integrations, backend systems and operational product work.",
+    en: "Software engineer specialized in backend and integrations.",
     es: "Ingeniero de software especializado en backend e integraciones."
   },
   domain: "https://hbonavota.com",
@@ -56,7 +56,6 @@ export const navigation = {
   en: [
     { label: "Work", href: "/work" },
     { label: "About", href: "/about" },
-    { label: "Orbytia", href: "/orbytia" },
     { label: "Contact", href: "/contact" }
   ],
   es: [
@@ -70,17 +69,16 @@ export const homeContent = {
   en: {
     hero: {
       eyebrow: "Hernán Bonavota",
-      title: "Software engineer for ticketing portals, integrations and backend systems.",
+      title: "Software engineer specialized in backend and integrations.",
       description:
-        "I work across ticketing, member validation, data flows and infrastructure where failures have direct operational cost.",
+        "I work on validation, concurrency and critical flows where failure impacts real operations.",
       primaryCta: { label: "See work", href: "/work" },
-      secondaryCta: { label: "Contact", href: "/contact" }
+      secondaryCta: { label: "LinkedIn", href: siteConfig.approvedLinks.linkedin }
     },
     selectedWork: {
       eyebrow: "Selected Work",
-      title: "Case studies from production work.",
-      description:
-        "Ticketing, member validation, concurrency control and product work, with concrete scope and decisions."
+      title: "Main case studies.",
+      description: "Concurrency, validation, and integrations with visible technical decisions."
     },
     capabilities: {
       eyebrow: "What I Cover",
@@ -90,9 +88,8 @@ export const homeContent = {
     },
     experience: {
       eyebrow: "Current Work",
-      title: "Current production scope.",
-      description:
-        "Today I work on ticketing, member validation, queueing, forms and infrastructure."
+      title: "Current experience.",
+      description: "Ticketing, member validation, and AWS-backed integrations."
     },
     ecosystem: {
       eyebrow: "Professional Context",
@@ -108,9 +105,8 @@ export const homeContent = {
     },
     contact: {
       eyebrow: "Contact",
-      title: "Open to engineering roles and technical conversations.",
-      description:
-        "LinkedIn is the best first contact for recruiters and hiring managers. Orbytia stays only as the separate route for service enquiries."
+      title: "Direct contact.",
+      description: "LinkedIn is the fastest way to reach me for recruiting or technical conversations."
     }
   },
   es: {
@@ -207,7 +203,7 @@ export const professionalExperience = {
     es: "Software Engineer / Product Engineer"
   },
   summary: {
-    en: "At Rezolve I work on ticketing portals, member validation, queueing, data update flows and AWS-backed operations for clubs in professional football.",
+    en: "At Rezolve I work on ticketing, member validation, and AWS-backed integrations for professional football clubs.",
     es: "En Rezolve trabajo en ticketing, validación de socios e integraciones sobre AWS para clubes de fútbol profesional."
   },
   notes: {
@@ -316,9 +312,8 @@ export const orbytiaPage = {
 
 export const contactPage = {
   en: {
-    title: "Open to engineering roles and technical conversations.",
-    description:
-      "For roles and technical conversations, LinkedIn is the best first contact. Orbytia is only for service enquiries."
+    title: "LinkedIn for first contact.",
+    description: "LinkedIn is the fastest way to reach me for recruiting or technical conversations."
   },
   es: {
     title: "LinkedIn para primer contacto.",


### PR DESCRIPTION
Align the English portfolio with the simplified Spanish version.

Changes:
- Shorter, clearer English hero
- Same recruiter-first homepage structure as ES
- Removed Orbytia from the main English flow
- Removed premium hero placement for Verifiko
- Simplified English contact flow around LinkedIn
- Aligned footer and metadata with the new positioning
- Updated English work page to match the same editorial logic as ES

Validation:
- npm run typecheck ✅
- npm run build ✅